### PR TITLE
fix Message.is_scheduled field always False when parsing UpdateNewScheduledMessage

### DIFF
--- a/hydrogram/dispatcher.py
+++ b/hydrogram/dispatcher.py
@@ -92,7 +92,7 @@ class Dispatcher:
                     update.message,
                     users,
                     chats,
-                    isinstance(update, UpdateNewScheduledMessage),
+                    is_scheduled=isinstance(update, UpdateNewScheduledMessage),
                 ),
                 MessageHandler,
             )

--- a/hydrogram/dispatcher.py
+++ b/hydrogram/dispatcher.py
@@ -88,10 +88,10 @@ class Dispatcher:
         async def message_parser(update, users, chats):
             return (
                 await hydrogram.types.Message._parse(
-                    self.client,
-                    update.message,
-                    users,
-                    chats,
+                    client=self.client,
+                    message=update.message,
+                    users=users,
+                    chats=chats,
                     is_scheduled=isinstance(update, UpdateNewScheduledMessage),
                 ),
                 MessageHandler,

--- a/hydrogram/methods/bots/send_game.py
+++ b/hydrogram/methods/bots/send_game.py
@@ -101,9 +101,9 @@ class SendGame:
         for i in r.updates:
             if isinstance(i, (raw.types.UpdateNewMessage, raw.types.UpdateNewChannelMessage)):
                 return await types.Message._parse(
-                    self,
-                    i.message,
-                    {i.id: i for i in r.users},
-                    {i.id: i for i in r.chats},
+                    client=self,
+                    message=i.message,
+                    users={i.id: i for i in r.users},
+                    chats={i.id: i for i in r.chats},
                 )
         return None

--- a/hydrogram/methods/bots/set_game_score.py
+++ b/hydrogram/methods/bots/set_game_score.py
@@ -91,10 +91,10 @@ class SetGameScore:
         for i in r.updates:
             if isinstance(i, (raw.types.UpdateEditMessage, raw.types.UpdateEditChannelMessage)):
                 return await types.Message._parse(
-                    self,
-                    i.message,
-                    {i.id: i for i in r.users},
-                    {i.id: i for i in r.chats},
+                    client=self,
+                    message=i.message,
+                    users={i.id: i for i in r.users},
+                    chats={i.id: i for i in r.chats},
                 )
 
         return True

--- a/hydrogram/methods/chats/ban_chat_member.py
+++ b/hydrogram/methods/chats/ban_chat_member.py
@@ -100,9 +100,9 @@ class BanChatMember:
         for i in r.updates:
             if isinstance(i, (raw.types.UpdateNewMessage, raw.types.UpdateNewChannelMessage)):
                 return await types.Message._parse(
-                    self,
-                    i.message,
-                    {i.id: i for i in r.users},
-                    {i.id: i for i in r.chats},
+                    client=self,
+                    message=i.message,
+                    users={i.id: i for i in r.users},
+                    chats={i.id: i for i in r.chats},
                 )
         return True

--- a/hydrogram/methods/chats/get_dialogs.py
+++ b/hydrogram/methods/chats/get_dialogs.py
@@ -77,7 +77,9 @@ class GetDialogs:
                     continue
 
                 chat_id = utils.get_peer_id(message.peer_id)
-                messages[chat_id] = await types.Message._parse(self, message, users, chats)
+                messages[chat_id] = await types.Message._parse(
+                    client=self, message=message, users=users, chats=chats
+                )
 
             dialogs = [
                 types.Dialog._parse(self, dialog, messages, users, chats)

--- a/hydrogram/methods/messages/edit_message_media.py
+++ b/hydrogram/methods/messages/edit_message_media.py
@@ -273,9 +273,9 @@ class EditMessageMedia:
         for i in r.updates:
             if isinstance(i, (raw.types.UpdateEditMessage, raw.types.UpdateEditChannelMessage)):
                 return await types.Message._parse(
-                    self,
-                    i.message,
-                    {i.id: i for i in r.users},
-                    {i.id: i for i in r.chats},
+                    client=self,
+                    message=i.message,
+                    users={i.id: i for i in r.users},
+                    chats={i.id: i for i in r.chats},
                 )
         return None

--- a/hydrogram/methods/messages/edit_message_reply_markup.py
+++ b/hydrogram/methods/messages/edit_message_reply_markup.py
@@ -71,9 +71,9 @@ class EditMessageReplyMarkup:
         for i in r.updates:
             if isinstance(i, (raw.types.UpdateEditMessage, raw.types.UpdateEditChannelMessage)):
                 return await types.Message._parse(
-                    self,
-                    i.message,
-                    {i.id: i for i in r.users},
-                    {i.id: i for i in r.chats},
+                    client=self,
+                    message=i.message,
+                    users={i.id: i for i in r.users},
+                    chats={i.id: i for i in r.chats},
                 )
         return None

--- a/hydrogram/methods/messages/edit_message_text.py
+++ b/hydrogram/methods/messages/edit_message_text.py
@@ -91,9 +91,9 @@ class EditMessageText:
         for i in r.updates:
             if isinstance(i, (raw.types.UpdateEditMessage, raw.types.UpdateEditChannelMessage)):
                 return await types.Message._parse(
-                    self,
-                    i.message,
-                    {i.id: i for i in r.users},
-                    {i.id: i for i in r.chats},
+                    client=self,
+                    message=i.message,
+                    users={i.id: i for i in r.users},
+                    chats={i.id: i for i in r.chats},
                 )
         return None

--- a/hydrogram/methods/messages/forward_messages.py
+++ b/hydrogram/methods/messages/forward_messages.py
@@ -105,7 +105,7 @@ class ForwardMessages:
         chats = {i.id: i for i in r.chats}
 
         forwarded_messages: list = [
-            await types.Message._parse(self, i.message, users, chats)
+            await types.Message._parse(client=self, message=i.message, users=users, chats=chats)
             for i in r.updates
             if isinstance(
                 i,

--- a/hydrogram/methods/messages/get_discussion_message.py
+++ b/hydrogram/methods/messages/get_discussion_message.py
@@ -61,4 +61,6 @@ class GetDiscussionMessage:
         users = {u.id: u for u in r.users}
         chats = {c.id: c for c in r.chats}
 
-        return await types.Message._parse(self, r.messages[0], users, chats)
+        return await types.Message._parse(
+            client=self, message=r.messages[0], users=users, chats=chats
+        )

--- a/hydrogram/methods/messages/get_discussion_replies.py
+++ b/hydrogram/methods/messages/get_discussion_replies.py
@@ -80,7 +80,9 @@ class GetDiscussionReplies:
                 return
 
             for message in messages:
-                yield await types.Message._parse(self, message, users, chats, replies=0)
+                yield await types.Message._parse(
+                    client=self, message=message, users=users, chats=chats, replies=0
+                )
 
                 current += 1
 

--- a/hydrogram/methods/messages/send_audio.py
+++ b/hydrogram/methods/messages/send_audio.py
@@ -244,10 +244,10 @@ class SendAudio:
                             ),
                         ):
                             return await types.Message._parse(
-                                self,
-                                i.message,
-                                {i.id: i for i in r.users},
-                                {i.id: i for i in r.chats},
+                                client=self,
+                                message=i.message,
+                                users={i.id: i for i in r.users},
+                                chats={i.id: i for i in r.chats},
                                 is_scheduled=isinstance(i, raw.types.UpdateNewScheduledMessage),
                             )
         except StopTransmission:

--- a/hydrogram/methods/messages/send_cached_media.py
+++ b/hydrogram/methods/messages/send_cached_media.py
@@ -129,10 +129,10 @@ class SendCachedMedia:
                 ),
             ):
                 return await types.Message._parse(
-                    self,
-                    i.message,
-                    {i.id: i for i in r.users},
-                    {i.id: i for i in r.chats},
+                    client=self,
+                    message=i.message,
+                    users={i.id: i for i in r.users},
+                    chats={i.id: i for i in r.chats},
                     is_scheduled=isinstance(i, raw.types.UpdateNewScheduledMessage),
                 )
         return None

--- a/hydrogram/methods/messages/send_contact.py
+++ b/hydrogram/methods/messages/send_contact.py
@@ -128,10 +128,10 @@ class SendContact:
                 ),
             ):
                 return await types.Message._parse(
-                    self,
-                    i.message,
-                    {i.id: i for i in r.users},
-                    {i.id: i for i in r.chats},
+                    client=self,
+                    message=i.message,
+                    users={i.id: i for i in r.users},
+                    chats={i.id: i for i in r.chats},
                     is_scheduled=isinstance(i, raw.types.UpdateNewScheduledMessage),
                 )
         return None

--- a/hydrogram/methods/messages/send_dice.py
+++ b/hydrogram/methods/messages/send_dice.py
@@ -122,10 +122,10 @@ class SendDice:
                 ),
             ):
                 return await types.Message._parse(
-                    self,
-                    i.message,
-                    {i.id: i for i in r.users},
-                    {i.id: i for i in r.chats},
+                    client=self,
+                    message=i.message,
+                    users={i.id: i for i in r.users},
+                    chats={i.id: i for i in r.chats},
                     is_scheduled=isinstance(i, raw.types.UpdateNewScheduledMessage),
                 )
         return None

--- a/hydrogram/methods/messages/send_document.py
+++ b/hydrogram/methods/messages/send_document.py
@@ -229,10 +229,10 @@ class SendDocument:
                             ),
                         ):
                             return await types.Message._parse(
-                                self,
-                                i.message,
-                                {i.id: i for i in r.users},
-                                {i.id: i for i in r.chats},
+                                client=self,
+                                message=i.message,
+                                users={i.id: i for i in r.users},
+                                chats={i.id: i for i in r.chats},
                                 is_scheduled=isinstance(i, raw.types.UpdateNewScheduledMessage),
                             )
         except StopTransmission:

--- a/hydrogram/methods/messages/send_location.py
+++ b/hydrogram/methods/messages/send_location.py
@@ -117,10 +117,10 @@ class SendLocation:
                 ),
             ):
                 return await types.Message._parse(
-                    self,
-                    i.message,
-                    {i.id: i for i in r.users},
-                    {i.id: i for i in r.chats},
+                    client=self,
+                    message=i.message,
+                    users={i.id: i for i in r.users},
+                    chats={i.id: i for i in r.chats},
                     is_scheduled=isinstance(i, raw.types.UpdateNewScheduledMessage),
                 )
         return None

--- a/hydrogram/methods/messages/send_message.py
+++ b/hydrogram/methods/messages/send_message.py
@@ -176,10 +176,10 @@ class SendMessage:
                 ),
             ):
                 return await types.Message._parse(
-                    self,
-                    i.message,
-                    {i.id: i for i in r.users},
-                    {i.id: i for i in r.chats},
+                    client=self,
+                    message=i.message,
+                    users={i.id: i for i in r.users},
+                    chats={i.id: i for i in r.chats},
                     is_scheduled=isinstance(i, raw.types.UpdateNewScheduledMessage),
                 )
         return None

--- a/hydrogram/methods/messages/send_photo.py
+++ b/hydrogram/methods/messages/send_photo.py
@@ -205,10 +205,10 @@ class SendPhoto:
                             ),
                         ):
                             return await types.Message._parse(
-                                self,
-                                i.message,
-                                {i.id: i for i in r.users},
-                                {i.id: i for i in r.chats},
+                                client=self,
+                                message=i.message,
+                                users={i.id: i for i in r.users},
+                                chats={i.id: i for i in r.chats},
                                 is_scheduled=isinstance(i, raw.types.UpdateNewScheduledMessage),
                             )
         except hydrogram.StopTransmission:

--- a/hydrogram/methods/messages/send_poll.py
+++ b/hydrogram/methods/messages/send_poll.py
@@ -191,10 +191,10 @@ class SendPoll:
                 ),
             ):
                 return await types.Message._parse(
-                    self,
-                    i.message,
-                    {i.id: i for i in r.users},
-                    {i.id: i for i in r.chats},
+                    client=self,
+                    message=i.message,
+                    users={i.id: i for i in r.users},
+                    chats={i.id: i for i in r.chats},
                     is_scheduled=isinstance(i, raw.types.UpdateNewScheduledMessage),
                 )
         return None

--- a/hydrogram/methods/messages/send_sticker.py
+++ b/hydrogram/methods/messages/send_sticker.py
@@ -181,10 +181,10 @@ class SendSticker:
                             ),
                         ):
                             return await types.Message._parse(
-                                self,
-                                i.message,
-                                {i.id: i for i in r.users},
-                                {i.id: i for i in r.chats},
+                                client=self,
+                                message=i.message,
+                                users={i.id: i for i in r.users},
+                                chats={i.id: i for i in r.chats},
                                 is_scheduled=isinstance(i, raw.types.UpdateNewScheduledMessage),
                             )
         except StopTransmission:

--- a/hydrogram/methods/messages/send_venue.py
+++ b/hydrogram/methods/messages/send_venue.py
@@ -141,10 +141,10 @@ class SendVenue:
                 ),
             ):
                 return await types.Message._parse(
-                    self,
-                    i.message,
-                    {i.id: i for i in r.users},
-                    {i.id: i for i in r.chats},
+                    client=self,
+                    message=i.message,
+                    users={i.id: i for i in r.users},
+                    chats={i.id: i for i in r.chats},
                     is_scheduled=isinstance(i, raw.types.UpdateNewScheduledMessage),
                 )
         return None

--- a/hydrogram/methods/messages/send_video.py
+++ b/hydrogram/methods/messages/send_video.py
@@ -269,10 +269,10 @@ class SendVideo:
                             ),
                         ):
                             return await types.Message._parse(
-                                self,
-                                i.message,
-                                {i.id: i for i in r.users},
-                                {i.id: i for i in r.chats},
+                                client=self,
+                                message=i.message,
+                                users={i.id: i for i in r.users},
+                                chats={i.id: i for i in r.chats},
                                 is_scheduled=isinstance(i, raw.types.UpdateNewScheduledMessage),
                             )
         except StopTransmission:

--- a/hydrogram/methods/messages/send_video_note.py
+++ b/hydrogram/methods/messages/send_video_note.py
@@ -206,10 +206,10 @@ class SendVideoNote:
                             ),
                         ):
                             return await types.Message._parse(
-                                self,
-                                i.message,
-                                {i.id: i for i in r.users},
-                                {i.id: i for i in r.chats},
+                                client=self,
+                                message=i.message,
+                                users={i.id: i for i in r.users},
+                                chats={i.id: i for i in r.chats},
                                 is_scheduled=isinstance(i, raw.types.UpdateNewScheduledMessage),
                             )
         except StopTransmission:

--- a/hydrogram/methods/messages/send_voice.py
+++ b/hydrogram/methods/messages/send_voice.py
@@ -200,10 +200,10 @@ class SendVoice:
                             ),
                         ):
                             return await types.Message._parse(
-                                self,
-                                i.message,
-                                {i.id: i for i in r.users},
-                                {i.id: i for i in r.chats},
+                                client=self,
+                                message=i.message,
+                                users={i.id: i for i in r.users},
+                                chats={i.id: i for i in r.chats},
                                 is_scheduled=isinstance(i, raw.types.UpdateNewScheduledMessage),
                             )
         except StopTransmission:

--- a/hydrogram/types/messages_and_media/message.py
+++ b/hydrogram/types/messages_and_media/message.py
@@ -507,6 +507,7 @@ class Message(Object, Update):
 
     @staticmethod
     async def _parse(
+        *,
         client: "hydrogram.Client",
         message: raw.base.Message,
         users: dict,

--- a/hydrogram/types/user_and_chats/chat_event.py
+++ b/hydrogram/types/user_and_chats/chat_event.py
@@ -362,12 +362,18 @@ class ChatEvent(Object):
             action = enums.ChatEventAction.CHAT_PERMISSIONS_CHANGED
 
         elif isinstance(action, raw.types.ChannelAdminLogEventActionDeleteMessage):
-            deleted_message = await types.Message._parse(client, action.message, users, chats)
+            deleted_message = await types.Message._parse(
+                client=client, message=action.message, users=users, chats=chats
+            )
             action = enums.ChatEventAction.MESSAGE_DELETED
 
         elif isinstance(action, raw.types.ChannelAdminLogEventActionEditMessage):
-            old_message = await types.Message._parse(client, action.prev_message, users, chats)
-            new_message = await types.Message._parse(client, action.new_message, users, chats)
+            old_message = await types.Message._parse(
+                client=client, message=action.prev_message, users=users, chats=chats
+            )
+            new_message = await types.Message._parse(
+                client=client, message=action.new_message, users=users, chats=chats
+            )
             action = enums.ChatEventAction.MESSAGE_EDITED
 
         elif isinstance(action, raw.types.ChannelAdminLogEventActionParticipantInvite):
@@ -393,7 +399,9 @@ class ChatEvent(Object):
             action = enums.ChatEventAction.MEMBER_PERMISSIONS_CHANGED
 
         elif isinstance(action, raw.types.ChannelAdminLogEventActionStopPoll):
-            stopped_poll = await types.Message._parse(client, action.message, users, chats)
+            stopped_poll = await types.Message._parse(
+                client=client, message=action.message, users=users, chats=chats
+            )
             action = enums.ChatEventAction.POLL_STOPPED
 
         elif isinstance(action, raw.types.ChannelAdminLogEventActionParticipantJoin):
@@ -423,10 +431,14 @@ class ChatEvent(Object):
             message = action.message
 
             if message.pinned:
-                pinned_message = await types.Message._parse(client, message, users, chats)
+                pinned_message = await types.Message._parse(
+                    client=client, message=message, users=users, chats=chats
+                )
                 action = enums.ChatEventAction.MESSAGE_PINNED
             else:
-                unpinned_message = await types.Message._parse(client, message, users, chats)
+                unpinned_message = await types.Message._parse(
+                    client=client, message=message, users=users, chats=chats
+                )
                 action = enums.ChatEventAction.MESSAGE_UNPINNED
 
         elif isinstance(action, raw.types.ChannelAdminLogEventActionExportedInviteEdit):

--- a/hydrogram/utils.py
+++ b/hydrogram/utils.py
@@ -96,7 +96,9 @@ async def parse_messages(
     parsed_messages = []
 
     parsed_messages = [
-        await types.Message._parse(client, message, users, chats, topics, replies=0)
+        await types.Message._parse(
+            client=client, message=message, users=users, chats=chats, topics=topics, replies=0
+        )
         for message in messages.messages
     ]
 

--- a/news/14.bugfix.rst
+++ b/news/14.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed `Message.is_scheduled` field being always `False` when parsing `UpdateNewScheduledMessage`

--- a/news/14.misc.rst
+++ b/news/14.misc.rst
@@ -1,0 +1,1 @@
+Make `Message._parse` accept only keyword-only arguments


### PR DESCRIPTION
## Description

Because i put topics parameter before is_scheduled in Message._parse method, everytime client get UpdateNewScheduledMessage updates the is_scheduled field will always False
Add the parameter name fix the issue

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
I test using my private bot, before this fix everytime i scheduled a message the is_scheduled field always return False and after this fix its return True

### Test Configuration

- Operating System: Ubuntu 22.04
- Python Version: 3.10

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
