### PR TITLE
fix: use `get_session` to get session when download

### DIFF
--- a/hydrogram/client.py
+++ b/hydrogram/client.py
@@ -48,7 +48,8 @@ from hydrogram.errors import (
     VolumeLocNotFound,
 )
 from hydrogram.handlers.handler import Handler
-from hydrogram.methods import Methods, get_session
+from hydrogram.methods import Methods
+from hydrogram.methods.messages.inline_session import get_session
 from hydrogram.session import Auth, Session
 from hydrogram.storage import BaseStorage, SQLiteStorage
 from hydrogram.types import ListenerTypes, TermsOfService, User

--- a/hydrogram/client.py
+++ b/hydrogram/client.py
@@ -48,7 +48,7 @@ from hydrogram.errors import (
     VolumeLocNotFound,
 )
 from hydrogram.handlers.handler import Handler
-from hydrogram.methods import Methods
+from hydrogram.methods import Methods, get_session
 from hydrogram.session import Auth, Session
 from hydrogram.storage import BaseStorage, SQLiteStorage
 from hydrogram.types import TermsOfService, User
@@ -929,30 +929,8 @@ class Client(Methods):
 
             dc_id = file_id.dc_id
 
-            session = Session(
-                self,
-                dc_id,
-                await Auth(self, dc_id, await self.storage.test_mode()).create()
-                if dc_id != await self.storage.dc_id()
-                else await self.storage.auth_key(),
-                await self.storage.test_mode(),
-                is_media=True,
-            )
-
             try:
-                await session.start()
-
-                if dc_id != await self.storage.dc_id():
-                    exported_auth = await self.invoke(
-                        raw.functions.auth.ExportAuthorization(dc_id=dc_id)
-                    )
-
-                    await session.invoke(
-                        raw.functions.auth.ImportAuthorization(
-                            id=exported_auth.id, bytes=exported_auth.bytes
-                        )
-                    )
-
+                session = await get_session(self, dc_id)
                 r = await session.invoke(
                     raw.functions.upload.GetFile(
                         location=location, offset=offset_bytes, limit=chunk_size

--- a/hydrogram/methods/__init__.py
+++ b/hydrogram/methods/__init__.py
@@ -28,7 +28,7 @@ from .messages import Messages
 from .password import Password
 from .users import Users
 from .utilities import Utilities
-from .messages.inline_session import get_session
+
 
 class Methods(
     Advanced,

--- a/hydrogram/methods/__init__.py
+++ b/hydrogram/methods/__init__.py
@@ -28,7 +28,7 @@ from .messages import Messages
 from .password import Password
 from .users import Users
 from .utilities import Utilities
-
+from .messages.inline_session import get_session
 
 class Methods(
     Advanced,

--- a/news/15.fix.rst
+++ b/news/15.fix.rst
@@ -1,0 +1,1 @@
+Use `get_session` to get session when downloadind files


### PR DESCRIPTION
## Description

Use get_session to replace the way to get the session when downloading

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Download problems no longer occur during long downloads
also can see my project [tdl](https://github.com/tangyoha/telegram_media_downloader)
[modified pyrogram](https://github.com/tangyoha/pyrogram)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
