### PR TITLE
fix: make quiz explanation optional

### DIFF
--- a/hydrogram/methods/messages/send_poll.py
+++ b/hydrogram/methods/messages/send_poll.py
@@ -140,10 +140,14 @@ class SendPoll:
         """
 
         solution, solution_entities = (
-            await utils.parse_text_entities(
-                self, explanation, explanation_parse_mode, explanation_entities
-            )
-        ).values() if explanation else (None, None)
+            (
+                await utils.parse_text_entities(
+                    self, explanation, explanation_parse_mode, explanation_entities
+                )
+            ).values()
+            if explanation
+            else (None, None)
+        )
 
         reply_to = utils.get_reply_head_fm(message_thread_id, reply_to_message_id)
 

--- a/hydrogram/methods/messages/send_poll.py
+++ b/hydrogram/methods/messages/send_poll.py
@@ -143,7 +143,7 @@ class SendPoll:
             await utils.parse_text_entities(
                 self, explanation, explanation_parse_mode, explanation_entities
             )
-        ).values()
+        ).values() if explanation else (None, None)
 
         reply_to = utils.get_reply_head_fm(message_thread_id, reply_to_message_id)
 
@@ -169,7 +169,7 @@ class SendPoll:
                     if correct_option_id is not None
                     else None,
                     solution=solution,
-                    solution_entities=solution_entities or [],
+                    solution_entities=None if solution is None else (solution_entities or []),
                 ),
                 message="",
                 silent=disable_notification,

--- a/news/21.bugfix.rst
+++ b/news/21.bugfix.rst
@@ -1,0 +1,1 @@
+Make the quiz explanation an optional parameter


### PR DESCRIPTION
## Description

Currently, there's no way to create a poll ("quiz" type) without any explanation using Client.send_poll.
When explanation parameter is not passed (explanation=None), current code stringifies None to "None".
But, when explanation=None, explanation_entities is required to be None too (explanation_entities=None), while current solution forces explanation_entities to always be a list.
This patch ensures that the required cases get handled properly, fixing the current bugs.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I manually tested various combinations of parameters (explanation and explanation_entities) of Client.send_poll.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes