### PR TITLE
refactor: `from __future__ import annotations` to simplify typing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: check-yaml
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.4
+    rev: v0.4.5
     hooks:
       - id: ruff-format
       - id: ruff

--- a/hydrogram/client.py
+++ b/hydrogram/client.py
@@ -17,6 +17,8 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import asyncio
 import contextlib
 import functools
@@ -27,7 +29,6 @@ import platform
 import re
 import shutil
 import sys
-from collections.abc import AsyncGenerator
 from concurrent.futures.thread import ThreadPoolExecutor
 from datetime import datetime, timedelta
 from hashlib import sha256
@@ -35,7 +36,7 @@ from importlib import import_module
 from io import BytesIO, StringIO
 from mimetypes import MimeTypes
 from pathlib import Path
-from typing import Callable, Optional, Union
+from typing import TYPE_CHECKING, Callable
 
 import hydrogram
 from hydrogram import __license__, __version__, enums, raw, utils
@@ -60,6 +61,9 @@ from .file_id import FileId, FileType, ThumbnailSource
 from .mime_types import mime_types
 from .parser import Parser
 from .session.internals import MsgId
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
 
 log = logging.getLogger(__name__)
 
@@ -211,28 +215,28 @@ class Client(Methods):
     def __init__(
         self,
         name: str,
-        api_id: Optional[Union[int, str]] = None,
-        api_hash: Optional[str] = None,
+        api_id: int | str | None = None,
+        api_hash: str | None = None,
         app_version: str = APP_VERSION,
         device_model: str = DEVICE_MODEL,
         system_version: str = SYSTEM_VERSION,
         lang_code: str = LANG_CODE,
         ipv6: bool = False,
-        proxy: Optional[dict] = None,
+        proxy: dict | None = None,
         test_mode: bool = False,
-        bot_token: Optional[str] = None,
-        session_string: Optional[str] = None,
-        session_storage_engine: Optional[BaseStorage] = None,
-        in_memory: Optional[bool] = None,
-        phone_number: Optional[str] = None,
-        phone_code: Optional[str] = None,
-        password: Optional[str] = None,
+        bot_token: str | None = None,
+        session_string: str | None = None,
+        session_storage_engine: BaseStorage | None = None,
+        in_memory: bool | None = None,
+        phone_number: str | None = None,
+        phone_code: str | None = None,
+        password: str | None = None,
         workers: int = WORKERS,
         workdir: str = str(WORKDIR),
-        plugins: Optional[dict] = None,
-        parse_mode: "enums.ParseMode" = enums.ParseMode.DEFAULT,
-        no_updates: Optional[bool] = None,
-        takeout: Optional[bool] = None,
+        plugins: dict | None = None,
+        parse_mode: enums.ParseMode = enums.ParseMode.DEFAULT,
+        no_updates: bool | None = None,
+        takeout: bool | None = None,
         sleep_threshold: int = Session.SLEEP_THRESHOLD,
         hide_password: bool = False,
         max_concurrent_transmissions: int = MAX_CONCURRENT_TRANSMISSIONS,
@@ -299,7 +303,7 @@ class Client(Methods):
 
         self.disconnect_handler = None
 
-        self.me: Optional[User] = None
+        self.me: User | None = None
 
         self.message_cache = Cache(10000)
 
@@ -463,7 +467,7 @@ class Client(Methods):
 
         return signed_up
 
-    def set_parse_mode(self, parse_mode: Optional["enums.ParseMode"]):
+    def set_parse_mode(self, parse_mode: enums.ParseMode | None):
         """Set the parse mode to be used globally by the client.
 
         When setting the parse mode with this method, all other methods having a *parse_mode* parameter will follow the
@@ -502,7 +506,7 @@ class Client(Methods):
         self.parse_mode = parse_mode
 
     async def fetch_peers(
-        self, peers: list[Union[raw.types.User, raw.types.Chat, raw.types.Channel]]
+        self, peers: list[raw.types.User | raw.types.Chat | raw.types.Channel]
     ) -> bool:
         is_min = False
         parsed_peers = []
@@ -884,9 +888,9 @@ class Client(Methods):
         file_size: int = 0,
         limit: int = 0,
         offset: int = 0,
-        progress: Optional[Callable] = None,
+        progress: Callable | None = None,
         progress_args: tuple = (),
-    ) -> Optional[AsyncGenerator[bytes, None]]:
+    ) -> AsyncGenerator[bytes, None] | None:
         async with self.get_file_semaphore:
             file_type = file_id.file_type
 
@@ -1067,10 +1071,10 @@ class Client(Methods):
             finally:
                 await session.stop()
 
-    def guess_mime_type(self, filename: str) -> Optional[str]:
+    def guess_mime_type(self, filename: str) -> str | None:
         return self.mimetypes.guess_type(filename)[0]
 
-    def guess_extension(self, mime_type: str) -> Optional[str]:
+    def guess_extension(self, mime_type: str) -> str | None:
         return self.mimetypes.guess_extension(mime_type)
 
 

--- a/hydrogram/connection/connection.py
+++ b/hydrogram/connection/connection.py
@@ -17,9 +17,10 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import asyncio
 import logging
-from typing import Optional
 
 from hydrogram.session.internals import DataCenter
 
@@ -72,5 +73,5 @@ class Connection:
     async def send(self, data: bytes):
         await self.protocol.send(data)
 
-    async def recv(self) -> Optional[bytes]:
+    async def recv(self) -> bytes | None:
         return await self.protocol.recv()

--- a/hydrogram/connection/transport/tcp/tcp_abridged.py
+++ b/hydrogram/connection/transport/tcp/tcp_abridged.py
@@ -17,8 +17,9 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import logging
-from typing import Optional
 
 from .tcp import TCP
 
@@ -40,7 +41,7 @@ class TCPAbridged(TCP):
             (bytes([length]) if length <= 126 else b"\x7f" + length.to_bytes(3, "little")) + data
         )
 
-    async def recv(self, length: int = 0) -> Optional[bytes]:
+    async def recv(self, length: int = 0) -> bytes | None:
         length = await super().recv(1)
 
         if length is None:

--- a/hydrogram/connection/transport/tcp/tcp_abridged_o.py
+++ b/hydrogram/connection/transport/tcp/tcp_abridged_o.py
@@ -17,9 +17,10 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import logging
 import os
-from typing import Optional
 
 import hydrogram
 from hydrogram.crypto import aes
@@ -72,7 +73,7 @@ class TCPAbridgedO(TCP):
 
         await super().send(payload)
 
-    async def recv(self, length: int = 0) -> Optional[bytes]:
+    async def recv(self, length: int = 0) -> bytes | None:
         length = await super().recv(1)
 
         if length is None:

--- a/hydrogram/connection/transport/tcp/tcp_full.py
+++ b/hydrogram/connection/transport/tcp/tcp_full.py
@@ -17,10 +17,11 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import logging
 from binascii import crc32
 from struct import pack, unpack
-from typing import Optional
 
 from .tcp import TCP
 
@@ -44,7 +45,7 @@ class TCPFull(TCP):
 
         await super().send(data)
 
-    async def recv(self, length: int = 0) -> Optional[bytes]:
+    async def recv(self, length: int = 0) -> bytes | None:
         length = await super().recv(4)
 
         if length is None:

--- a/hydrogram/connection/transport/tcp/tcp_intermediate.py
+++ b/hydrogram/connection/transport/tcp/tcp_intermediate.py
@@ -17,9 +17,10 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import logging
 from struct import pack, unpack
-from typing import Optional
 
 from .tcp import TCP
 
@@ -37,7 +38,7 @@ class TCPIntermediate(TCP):
     async def send(self, data: bytes, *args):
         await super().send(pack("<i", len(data)) + data)
 
-    async def recv(self, length: int = 0) -> Optional[bytes]:
+    async def recv(self, length: int = 0) -> bytes | None:
         length = await super().recv(4)
 
         return None if length is None else await super().recv(unpack("<i", length)[0])

--- a/hydrogram/connection/transport/tcp/tcp_intermediate_o.py
+++ b/hydrogram/connection/transport/tcp/tcp_intermediate_o.py
@@ -17,10 +17,11 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import logging
 import os
 from struct import pack, unpack
-from typing import Optional
 
 from hydrogram.crypto import aes
 
@@ -64,7 +65,7 @@ class TCPIntermediateO(TCP):
     async def send(self, data: bytes, *args):
         await super().send(aes.ctr256_encrypt(pack("<i", len(data)) + data, *self.encrypt))
 
-    async def recv(self, length: int = 0) -> Optional[bytes]:
+    async def recv(self, length: int = 0) -> bytes | None:
         length = await super().recv(4)
 
         if length is None:

--- a/hydrogram/crypto/aes.py
+++ b/hydrogram/crypto/aes.py
@@ -17,8 +17,9 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import logging
-from typing import Optional
 
 log = logging.getLogger(__name__)
 
@@ -34,12 +35,12 @@ try:
         return tgcrypto.ige256_decrypt(data, key, iv)
 
     def ctr256_encrypt(
-        data: bytes, key: bytes, iv: bytearray, state: Optional[bytearray] = None
+        data: bytes, key: bytes, iv: bytearray, state: bytearray | None = None
     ) -> bytes:
         return tgcrypto.ctr256_encrypt(data, key, iv, state or bytearray(1))
 
     def ctr256_decrypt(
-        data: bytes, key: bytes, iv: bytearray, state: Optional[bytearray] = None
+        data: bytes, key: bytes, iv: bytearray, state: bytearray | None = None
     ) -> bytes:
         return tgcrypto.ctr256_decrypt(data, key, iv, state or bytearray(1))
 
@@ -65,12 +66,12 @@ except ImportError:
         return ige(data, key, iv, False)
 
     def ctr256_encrypt(
-        data: bytes, key: bytes, iv: bytearray, state: Optional[bytearray] = None
+        data: bytes, key: bytes, iv: bytearray, state: bytearray | None = None
     ) -> bytes:
         return ctr(data, key, iv, state or bytearray(1))
 
     def ctr256_decrypt(
-        data: bytes, key: bytes, iv: bytearray, state: Optional[bytearray] = None
+        data: bytes, key: bytes, iv: bytearray, state: bytearray | None = None
     ) -> bytes:
         return ctr(data, key, iv, state or bytearray(1))
 

--- a/hydrogram/errors/__init__.py
+++ b/hydrogram/errors/__init__.py
@@ -17,7 +17,9 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import ClassVar, Optional
+from __future__ import annotations
+
+from typing import ClassVar
 
 from .exceptions import (
     AboutTooLong,
@@ -531,14 +533,14 @@ class SecurityError(Exception):
 class SecurityCheckMismatch(SecurityError):  # noqa: N818
     """Raised when a security check mismatch occurs."""
 
-    def __init__(self, msg: Optional[str] = None):
+    def __init__(self, msg: str | None = None):
         super().__init__("A security check mismatch has occurred." if msg is None else msg)
 
 
 class CDNFileHashMismatch(SecurityError):  # noqa: N818
     """Raised when a CDN file hash mismatch occurs."""
 
-    def __init__(self, msg: Optional[str] = None):
+    def __init__(self, msg: str | None = None):
         super().__init__("A CDN file hash mismatch has occurred." if msg is None else msg)
 
 

--- a/hydrogram/errors/rpc_error.py
+++ b/hydrogram/errors/rpc_error.py
@@ -17,16 +17,19 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import re
 from datetime import datetime
 from importlib import import_module
 from pathlib import Path
-from typing import Optional, Union
-
-from hydrogram import raw
-from hydrogram.raw.core import TLObject
+from typing import TYPE_CHECKING
 
 from .exceptions.all import exceptions
+
+if TYPE_CHECKING:
+    from hydrogram import raw
+    from hydrogram.raw.core import TLObject
 
 
 class RPCError(Exception):
@@ -37,8 +40,8 @@ class RPCError(Exception):
 
     def __init__(
         self,
-        value: Union[int, str, raw.types.RpcError] = None,
-        rpc_name: Optional[str] = None,
+        value: int | str | raw.types.RpcError = None,
+        rpc_name: str | None = None,
         is_unknown: bool = False,
         is_signed: bool = False,
     ):
@@ -62,7 +65,7 @@ class RPCError(Exception):
                 f.write(f"{datetime.now()}\t{value}\t{rpc_name}\n")
 
     @staticmethod
-    def raise_it(rpc_error: "raw.types.RpcError", rpc_type: type[TLObject]):
+    def raise_it(rpc_error: raw.types.RpcError, rpc_type: type[TLObject]):
         error_code = rpc_error.error_code
         is_signed = error_code < 0
         error_message = rpc_error.error_message

--- a/hydrogram/file_id.py
+++ b/hydrogram/file_id.py
@@ -17,12 +17,13 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import base64
 import logging
 import struct
 from enum import IntEnum
 from io import BytesIO
-from typing import Optional
 
 from hydrogram.raw.core import Bytes, String
 
@@ -172,19 +173,19 @@ class FileId:
         file_type: FileType,
         dc_id: int,
         file_reference: bytes = b"",
-        url: Optional[str] = None,
-        media_id: Optional[int] = None,
-        access_hash: Optional[int] = None,
-        volume_id: Optional[int] = None,
+        url: str | None = None,
+        media_id: int | None = None,
+        access_hash: int | None = None,
+        volume_id: int | None = None,
         thumbnail_source: ThumbnailSource = None,
         thumbnail_file_type: FileType = None,
         thumbnail_size: str = "",
-        secret: Optional[int] = None,
-        local_id: Optional[int] = None,
-        chat_id: Optional[int] = None,
-        chat_access_hash: Optional[int] = None,
-        sticker_set_id: Optional[int] = None,
-        sticker_set_access_hash: Optional[int] = None,
+        secret: int | None = None,
+        local_id: int | None = None,
+        chat_id: int | None = None,
+        chat_access_hash: int | None = None,
+        sticker_set_id: int | None = None,
+        sticker_set_access_hash: int | None = None,
     ):
         self.major = major
         self.minor = minor
@@ -356,7 +357,7 @@ class FileId:
             )
         return None
 
-    def encode(self, *, major: Optional[int] = None, minor: Optional[int] = None):
+    def encode(self, *, major: int | None = None, minor: int | None = None):
         major = major if major is not None else self.major
         minor = minor if minor is not None else self.minor
 
@@ -440,10 +441,10 @@ class FileUniqueId:
         self,
         *,
         file_unique_type: FileUniqueType,
-        url: Optional[str] = None,
-        media_id: Optional[int] = None,
-        volume_id: Optional[int] = None,
-        local_id: Optional[int] = None,
+        url: str | None = None,
+        media_id: int | None = None,
+        volume_id: int | None = None,
+        local_id: int | None = None,
     ):
         self.file_unique_type = file_unique_type
         self.url = url

--- a/hydrogram/filters.py
+++ b/hydrogram/filters.py
@@ -17,10 +17,12 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import inspect
 import re
 from re import Pattern
-from typing import Callable, Optional, Union
+from typing import Callable
 
 import hydrogram
 from hydrogram import enums
@@ -35,7 +37,7 @@ from hydrogram.types import (
 
 
 class Filter:
-    async def __call__(self, client: "hydrogram.Client", update: Update):
+    async def __call__(self, client: hydrogram.Client, update: Update):
         raise NotImplementedError
 
     def __invert__(self):
@@ -52,7 +54,7 @@ class InvertFilter(Filter):
     def __init__(self, base):
         self.base = base
 
-    async def __call__(self, client: "hydrogram.Client", update: Update):
+    async def __call__(self, client: hydrogram.Client, update: Update):
         if inspect.iscoroutinefunction(self.base.__call__):
             x = await self.base(client, update)
         else:
@@ -66,7 +68,7 @@ class AndFilter(Filter):
         self.base = base
         self.other = other
 
-    async def __call__(self, client: "hydrogram.Client", update: Update):
+    async def __call__(self, client: hydrogram.Client, update: Update):
         if inspect.iscoroutinefunction(self.base.__call__):
             x = await self.base(client, update)
         else:
@@ -89,7 +91,7 @@ class OrFilter(Filter):
         self.base = base
         self.other = other
 
-    async def __call__(self, client: "hydrogram.Client", update: Update):
+    async def __call__(self, client: hydrogram.Client, update: Update):
         if inspect.iscoroutinefunction(self.base.__call__):
             x = await self.base(client, update)
         else:
@@ -110,7 +112,7 @@ class OrFilter(Filter):
 CUSTOM_FILTER_NAME = "CustomFilter"
 
 
-def create(func: Callable, name: Optional[str] = None, **kwargs) -> Filter:
+def create(func: Callable, name: str | None = None, **kwargs) -> Filter:
     """Easily create a custom filter.
 
     Custom filters give you extra control over which updates are allowed or not to be processed by your handlers.
@@ -788,8 +790,8 @@ linked_channel = create(linked_channel_filter)
 
 # region command_filter
 def command(
-    commands: Union[str, list[str]],
-    prefixes: Union[str, list[str]] = "/",
+    commands: str | list[str],
+    prefixes: str | list[str] = "/",
     case_sensitive: bool = False,
 ):
     """Filter commands, i.e.: text messages starting with "/" or any other custom prefix.
@@ -874,7 +876,7 @@ def command(
 # endregion
 
 
-def regex(pattern: Union[str, Pattern], flags: int = 0):
+def regex(pattern: str | Pattern, flags: int = 0):
     """Filter updates that match a given regular expression pattern.
 
     Can be applied to handlers that receive one of the following updates:
@@ -929,7 +931,7 @@ class user(Filter, set):  # noqa: N801
             Defaults to None (no users).
     """
 
-    def __init__(self, users: Optional[Union[int, str, list[Union[int, str]]]] = None):
+    def __init__(self, users: int | str | list[int | str] | None = None):
         users = [] if users is None else users if isinstance(users, list) else [users]
 
         super().__init__(
@@ -958,7 +960,7 @@ class chat(Filter, set):  # noqa: N801
             Defaults to None (no chats).
     """
 
-    def __init__(self, chats: Optional[Union[int, str, list[Union[int, str]]]] = None):
+    def __init__(self, chats: int | str | list[int | str] | None = None):
         chats = [] if chats is None else chats if isinstance(chats, list) else [chats]
 
         super().__init__(

--- a/hydrogram/handlers/callback_query_handler.py
+++ b/hydrogram/handlers/callback_query_handler.py
@@ -17,8 +17,10 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 from asyncio import iscoroutinefunction
-from typing import Callable, Optional
+from typing import Callable
 
 import hydrogram
 from hydrogram.types import CallbackQuery, Identifier, Listener, ListenerTypes
@@ -87,8 +89,8 @@ class CallbackQueryHandler(Handler):
         )
 
     async def check_if_has_matching_listener(
-        self, client: "hydrogram.Client", query: CallbackQuery
-    ) -> tuple[bool, Optional[Listener]]:
+        self, client: hydrogram.Client, query: CallbackQuery
+    ) -> tuple[bool, Listener | None]:
         """
         Checks if the CallbackQuery object has a matching listener.
 
@@ -123,7 +125,7 @@ class CallbackQueryHandler(Handler):
 
         return listener_does_match, listener
 
-    async def check(self, client: "hydrogram.Client", query: CallbackQuery) -> bool:
+    async def check(self, client: hydrogram.Client, query: CallbackQuery) -> bool:
         """
         Checks if the CallbackQuery object has a matching listener or handler.
 
@@ -180,7 +182,7 @@ class CallbackQueryHandler(Handler):
         return listener_does_match or handler_does_match
 
     async def resolve_future_or_callback(
-        self, client: "hydrogram.Client", query: CallbackQuery, *args
+        self, client: hydrogram.Client, query: CallbackQuery, *args
     ) -> None:
         """
         Resolves the future or calls the callback of the listener. Will call the original handler if no listener.

--- a/hydrogram/handlers/deleted_messages_handler.py
+++ b/hydrogram/handlers/deleted_messages_handler.py
@@ -17,13 +17,15 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Callable
+from typing import TYPE_CHECKING, Callable
 
-import hydrogram
 from hydrogram.filters import Filter
 from hydrogram.types import Message
 
 from .handler import Handler
+
+if TYPE_CHECKING:
+    import hydrogram
 
 
 class DeletedMessagesHandler(Handler):

--- a/hydrogram/handlers/handler.py
+++ b/hydrogram/handlers/handler.py
@@ -18,11 +18,13 @@
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import inspect
-from typing import Callable
+from typing import TYPE_CHECKING, Callable
 
-import hydrogram
 from hydrogram.filters import Filter
 from hydrogram.types import Update
+
+if TYPE_CHECKING:
+    import hydrogram
 
 
 class Handler:

--- a/hydrogram/handlers/message_handler.py
+++ b/hydrogram/handlers/message_handler.py
@@ -17,8 +17,10 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 from inspect import iscoroutinefunction
-from typing import Callable, Optional
+from typing import Callable
 
 import hydrogram
 from hydrogram.types import Identifier, Listener, ListenerTypes, Message
@@ -55,8 +57,8 @@ class MessageHandler(Handler):
         super().__init__(self.resolve_future_or_callback, filters)
 
     async def check_if_has_matching_listener(
-        self, client: "hydrogram.Client", message: Message
-    ) -> tuple[bool, Optional[Listener]]:
+        self, client: hydrogram.Client, message: Message
+    ) -> tuple[bool, Listener | None]:
         """
         Checks if the message has a matching listener.
 
@@ -101,7 +103,7 @@ class MessageHandler(Handler):
 
         return listener_does_match, listener
 
-    async def check(self, client: "hydrogram.Client", message: Message) -> bool:
+    async def check(self, client: hydrogram.Client, message: Message) -> bool:
         """
         Checks if the message has a matching listener or handler and its filters does match with the Message.
 
@@ -131,9 +133,7 @@ class MessageHandler(Handler):
         # exists but its filters doesn't match
         return listener_does_match or handler_does_match
 
-    async def resolve_future_or_callback(
-        self, client: "hydrogram.Client", message: Message, *args
-    ):
+    async def resolve_future_or_callback(self, client: hydrogram.Client, message: Message, *args):
         """
         Resolves the future or calls the callback of the listener if the message has a matching listener.
 

--- a/hydrogram/helpers/helpers.py
+++ b/hydrogram/helpers/helpers.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional, Union
+from __future__ import annotations
 
 from hydrogram.types import (
     ForceReply,
@@ -28,7 +28,7 @@ from hydrogram.types import (
 )
 
 
-def ikb(rows: Optional[list[list[Union[str, tuple[str, str]]]]] = None) -> InlineKeyboardMarkup:
+def ikb(rows: list[list[str | tuple[str, str]]] | None = None) -> InlineKeyboardMarkup:
     """
     Create an InlineKeyboardMarkup from a list of lists of buttons.
 
@@ -77,7 +77,7 @@ def btn(text: str, value: str, type="callback_data") -> InlineKeyboardButton:
 
 
 # The inverse of ikb()
-def bki(keyboard: InlineKeyboardButton) -> list[list[Union[str, tuple[str, str]]]]:
+def bki(keyboard: InlineKeyboardButton) -> list[list[str | tuple[str, str]]]:
     """
     Create a list of lists of buttons from an InlineKeyboardMarkup.
 

--- a/hydrogram/methods/advanced/invoke.py
+++ b/hydrogram/methods/advanced/invoke.py
@@ -17,24 +17,28 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import logging
-from typing import Optional
+from typing import TYPE_CHECKING
 
 import hydrogram
 from hydrogram import raw
-from hydrogram.raw.core import TLObject
 from hydrogram.session import Session
+
+if TYPE_CHECKING:
+    from hydrogram.raw.core import TLObject
 
 log = logging.getLogger(__name__)
 
 
 class Invoke:
     async def invoke(
-        self: "hydrogram.Client",
+        self: hydrogram.Client,
         query: TLObject,
         retries: int = Session.MAX_RETRIES,
         timeout: float = Session.WAIT_TIMEOUT,
-        sleep_threshold: Optional[float] = None,
+        sleep_threshold: float | None = None,
     ):
         """Invoke raw Telegram functions.
 

--- a/hydrogram/methods/advanced/resolve_peer.py
+++ b/hydrogram/methods/advanced/resolve_peer.py
@@ -17,9 +17,10 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import logging
 import re
-from typing import Union
 
 import hydrogram
 from hydrogram import raw, utils
@@ -30,8 +31,8 @@ log = logging.getLogger(__name__)
 
 class ResolvePeer:
     async def resolve_peer(
-        self: "hydrogram.Client", peer_id: Union[int, str]
-    ) -> Union[raw.base.InputPeer, raw.base.InputUser, raw.base.InputChannel]:
+        self: hydrogram.Client, peer_id: int | str
+    ) -> raw.base.InputPeer | raw.base.InputUser | raw.base.InputChannel:
         """Get the InputPeer of a known peer id.
         Useful whenever an InputPeer type is required.
 

--- a/hydrogram/methods/advanced/save_file.py
+++ b/hydrogram/methods/advanced/save_file.py
@@ -17,6 +17,8 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import asyncio
 import functools
 import inspect
@@ -25,7 +27,7 @@ import logging
 import math
 from hashlib import md5
 from pathlib import Path, PurePath
-from typing import BinaryIO, Callable, Optional, Union
+from typing import BinaryIO, Callable
 
 import hydrogram
 from hydrogram import StopTransmission, raw
@@ -36,11 +38,11 @@ log = logging.getLogger(__name__)
 
 class SaveFile:
     async def save_file(
-        self: "hydrogram.Client",
-        path: Union[str, BinaryIO],
-        file_id: Optional[int] = None,
+        self: hydrogram.Client,
+        path: str | BinaryIO,
+        file_id: int | None = None,
         file_part: int = 0,
-        progress: Optional[Callable] = None,
+        progress: Callable | None = None,
         progress_args: tuple = (),
     ):
         """Upload a file onto Telegram servers, without actually sending the message to anyone.

--- a/hydrogram/methods/auth/connect.py
+++ b/hydrogram/methods/auth/connect.py
@@ -17,8 +17,12 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-import hydrogram
+from typing import TYPE_CHECKING
+
 from hydrogram.session import Session
+
+if TYPE_CHECKING:
+    import hydrogram
 
 
 class Connect:

--- a/hydrogram/methods/auth/disconnect.py
+++ b/hydrogram/methods/auth/disconnect.py
@@ -17,7 +17,10 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-import hydrogram
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import hydrogram
 
 
 class Disconnect:

--- a/hydrogram/methods/auth/initialize.py
+++ b/hydrogram/methods/auth/initialize.py
@@ -19,8 +19,10 @@
 
 import asyncio
 import logging
+from typing import TYPE_CHECKING
 
-import hydrogram
+if TYPE_CHECKING:
+    import hydrogram
 
 log = logging.getLogger(__name__)
 

--- a/hydrogram/methods/bots/answer_callback_query.py
+++ b/hydrogram/methods/bots/answer_callback_query.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
@@ -25,11 +25,11 @@ from hydrogram import raw
 
 class AnswerCallbackQuery:
     async def answer_callback_query(
-        self: "hydrogram.Client",
+        self: hydrogram.Client,
         callback_query_id: str,
-        text: Optional[str] = None,
-        show_alert: Optional[bool] = None,
-        url: Optional[str] = None,
+        text: str | None = None,
+        show_alert: bool | None = None,
+        url: str | None = None,
         cache_time: int = 0,
     ):
         """Send answers to callback queries sent from inline keyboards.

--- a/hydrogram/methods/bots/get_bot_default_privileges.py
+++ b/hydrogram/methods/bots/get_bot_default_privileges.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw, types
@@ -25,8 +25,8 @@ from hydrogram import raw, types
 
 class GetBotDefaultPrivileges:
     async def get_bot_default_privileges(
-        self: "hydrogram.Client", for_channels: Optional[bool] = None
-    ) -> Optional["types.ChatPrivileges"]:
+        self: hydrogram.Client, for_channels: bool | None = None
+    ) -> types.ChatPrivileges | None:
         """Get the current default privileges of the bot.
 
         .. include:: /_includes/usable-by/bots.rst

--- a/hydrogram/methods/bots/get_chat_menu_button.py
+++ b/hydrogram/methods/bots/get_chat_menu_button.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional, Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw, types
@@ -25,9 +25,9 @@ from hydrogram import raw, types
 
 class GetChatMenuButton:
     async def get_chat_menu_button(
-        self: "hydrogram.Client",
-        chat_id: Optional[Union[int, str]] = None,
-    ) -> "types.MenuButton":
+        self: hydrogram.Client,
+        chat_id: int | str | None = None,
+    ) -> types.MenuButton:
         """Get the current value of the bot's menu button in a private chat, or the default menu button.
 
         .. include:: /_includes/usable-by/bots.rst

--- a/hydrogram/methods/bots/get_game_high_scores.py
+++ b/hydrogram/methods/bots/get_game_high_scores.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional, Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw, types
@@ -25,11 +25,11 @@ from hydrogram import raw, types
 
 class GetGameHighScores:
     async def get_game_high_scores(
-        self: "hydrogram.Client",
-        user_id: Union[int, str],
-        chat_id: Union[int, str],
-        message_id: Optional[int] = None,
-    ) -> list["types.GameHighScore"]:
+        self: hydrogram.Client,
+        user_id: int | str,
+        chat_id: int | str,
+        message_id: int | None = None,
+    ) -> list[types.GameHighScore]:
         """Get data for high score tables.
 
         .. include:: /_includes/usable-by/bots.rst

--- a/hydrogram/methods/bots/get_inline_bot_results.py
+++ b/hydrogram/methods/bots/get_inline_bot_results.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional, Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
@@ -26,12 +26,12 @@ from hydrogram.errors import UnknownError
 
 class GetInlineBotResults:
     async def get_inline_bot_results(
-        self: "hydrogram.Client",
-        bot: Union[int, str],
+        self: hydrogram.Client,
+        bot: int | str,
         query: str = "",
         offset: str = "",
-        latitude: Optional[float] = None,
-        longitude: Optional[float] = None,
+        latitude: float | None = None,
+        longitude: float | None = None,
     ):
         """Get bot results via inline queries.
         You can then send a result using :meth:`~hydrogram.Client.send_inline_bot_result`

--- a/hydrogram/methods/bots/request_callback_answer.py
+++ b/hydrogram/methods/bots/request_callback_answer.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
@@ -25,10 +25,10 @@ from hydrogram import raw
 
 class RequestCallbackAnswer:
     async def request_callback_answer(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
+        self: hydrogram.Client,
+        chat_id: int | str,
         message_id: int,
-        callback_data: Union[str, bytes],
+        callback_data: str | bytes,
         timeout: int = 10,
     ):
         """Request a callback answer from bots.

--- a/hydrogram/methods/bots/send_game.py
+++ b/hydrogram/methods/bots/send_game.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional, Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw, types, utils
@@ -25,21 +25,19 @@ from hydrogram import raw, types, utils
 
 class SendGame:
     async def send_game(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
+        self: hydrogram.Client,
+        chat_id: int | str,
         game_short_name: str,
         *,
-        message_thread_id: Optional[int] = None,
-        disable_notification: Optional[bool] = None,
-        reply_to_message_id: Optional[int] = None,
-        protect_content: Optional[bool] = None,
-        reply_markup: Union[
-            "types.InlineKeyboardMarkup",
-            "types.ReplyKeyboardMarkup",
-            "types.ReplyKeyboardRemove",
-            "types.ForceReply",
-        ] = None,
-    ) -> "types.Message":
+        message_thread_id: int | None = None,
+        disable_notification: bool | None = None,
+        reply_to_message_id: int | None = None,
+        protect_content: bool | None = None,
+        reply_markup: types.InlineKeyboardMarkup
+        | types.ReplyKeyboardMarkup
+        | types.ReplyKeyboardRemove
+        | types.ForceReply = None,
+    ) -> types.Message:
         """Send a game.
 
         .. include:: /_includes/usable-by/bots.rst

--- a/hydrogram/methods/bots/send_inline_bot_result.py
+++ b/hydrogram/methods/bots/send_inline_bot_result.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional, Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw, utils
@@ -25,15 +25,15 @@ from hydrogram import raw, utils
 
 class SendInlineBotResult:
     async def send_inline_bot_result(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
+        self: hydrogram.Client,
+        chat_id: int | str,
         query_id: int,
         result_id: str,
         *,
-        message_thread_id: Optional[int] = None,
-        disable_notification: Optional[bool] = None,
-        reply_to_message_id: Optional[int] = None,
-    ) -> "raw.base.Updates":
+        message_thread_id: int | None = None,
+        disable_notification: bool | None = None,
+        reply_to_message_id: int | None = None,
+    ) -> raw.base.Updates:
         """Send an inline bot result.
         Bot results can be retrieved using :meth:`~hydrogram.Client.get_inline_bot_results`
 

--- a/hydrogram/methods/bots/set_bot_default_privileges.py
+++ b/hydrogram/methods/bots/set_bot_default_privileges.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw, types
@@ -25,9 +25,9 @@ from hydrogram import raw, types
 
 class SetBotDefaultPrivileges:
     async def set_bot_default_privileges(
-        self: "hydrogram.Client",
-        privileges: "types.ChatPrivileges" = None,
-        for_channels: Optional[bool] = None,
+        self: hydrogram.Client,
+        privileges: types.ChatPrivileges = None,
+        for_channels: bool | None = None,
     ) -> bool:
         """Change the default privileges requested by the bot when it's added as an administrator to groups or channels.
 

--- a/hydrogram/methods/bots/set_chat_menu_button.py
+++ b/hydrogram/methods/bots/set_chat_menu_button.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional, Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw, types
@@ -25,9 +25,9 @@ from hydrogram import raw, types
 
 class SetChatMenuButton:
     async def set_chat_menu_button(
-        self: "hydrogram.Client",
-        chat_id: Optional[Union[int, str]] = None,
-        menu_button: "types.MenuButton" = None,
+        self: hydrogram.Client,
+        chat_id: int | str | None = None,
+        menu_button: types.MenuButton = None,
     ) -> bool:
         """Change the bot's menu button in a private chat, or the default menu button.
 

--- a/hydrogram/methods/bots/set_game_score.py
+++ b/hydrogram/methods/bots/set_game_score.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional, Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw, types
@@ -25,14 +25,14 @@ from hydrogram import raw, types
 
 class SetGameScore:
     async def set_game_score(
-        self: "hydrogram.Client",
-        user_id: Union[int, str],
+        self: hydrogram.Client,
+        user_id: int | str,
         score: int,
-        force: Optional[bool] = None,
-        disable_edit_message: Optional[bool] = None,
-        chat_id: Optional[Union[int, str]] = None,
-        message_id: Optional[int] = None,
-    ) -> Union["types.Message", bool]:
+        force: bool | None = None,
+        disable_edit_message: bool | None = None,
+        chat_id: int | str | None = None,
+        message_id: int | None = None,
+    ) -> types.Message | bool:
         # inline_message_id: str = None):  TODO Add inline_message_id
         """Set the score of the specified user in a game.
 

--- a/hydrogram/methods/chats/add_chat_members.py
+++ b/hydrogram/methods/chats/add_chat_members.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
@@ -25,9 +25,9 @@ from hydrogram import raw
 
 class AddChatMembers:
     async def add_chat_members(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
-        user_ids: Union[Union[int, str], list[Union[int, str]]],
+        self: hydrogram.Client,
+        chat_id: int | str,
+        user_ids: int | str | list[int | str],
         forward_limit: int = 100,
     ) -> bool:
         """Add new chat members to a group, supergroup or channel

--- a/hydrogram/methods/chats/archive_chats.py
+++ b/hydrogram/methods/chats/archive_chats.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
@@ -25,8 +25,8 @@ from hydrogram import raw
 
 class ArchiveChats:
     async def archive_chats(
-        self: "hydrogram.Client",
-        chat_ids: Union[int, str, list[Union[int, str]]],
+        self: hydrogram.Client,
+        chat_ids: int | str | list[int | str],
     ) -> bool:
         """Archive one or more chats.
 

--- a/hydrogram/methods/chats/ban_chat_member.py
+++ b/hydrogram/methods/chats/ban_chat_member.py
@@ -17,20 +17,24 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from datetime import datetime
-from typing import Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import hydrogram
 from hydrogram import raw, types, utils
 
+if TYPE_CHECKING:
+    from datetime import datetime
+
 
 class BanChatMember:
     async def ban_chat_member(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
-        user_id: Union[int, str],
+        self: hydrogram.Client,
+        chat_id: int | str,
+        user_id: int | str,
         until_date: datetime = utils.zero_datetime(),
-    ) -> Union["types.Message", bool]:
+    ) -> types.Message | bool:
         """Ban a user from a group, a supergroup or a channel.
         In the case of supergroups and channels, the user will not be able to return to the group on their own using
         invite links, etc., unless unbanned first. You must be an administrator in the chat for this to work and must

--- a/hydrogram/methods/chats/close_forum_topic.py
+++ b/hydrogram/methods/chats/close_forum_topic.py
@@ -16,16 +16,14 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
 
 
 class CloseForumTopic:
-    async def close_forum_topic(
-        self: "hydrogram.Client", chat_id: Union[int, str], topic_id: int
-    ) -> bool:
+    async def close_forum_topic(self: hydrogram.Client, chat_id: int | str, topic_id: int) -> bool:
         """Close a forum topic.
 
         .. include:: /_includes/usable-by/users-bots.rst

--- a/hydrogram/methods/chats/close_general_topic.py
+++ b/hydrogram/methods/chats/close_general_topic.py
@@ -16,14 +16,14 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
 
 
 class CloseGeneralTopic:
-    async def close_general_topic(self: "hydrogram.Client", chat_id: Union[int, str]) -> bool:
+    async def close_general_topic(self: hydrogram.Client, chat_id: int | str) -> bool:
         """Close a forum topic.
 
         .. include:: /_includes/usable-by/users-bots.rst

--- a/hydrogram/methods/chats/create_forum_topic.py
+++ b/hydrogram/methods/chats/create_forum_topic.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional, Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw, types
@@ -24,12 +24,12 @@ from hydrogram import raw, types
 
 class CreateForumTopic:
     async def create_forum_topic(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
+        self: hydrogram.Client,
+        chat_id: int | str,
         title: str,
-        icon_color: Optional[int] = None,
-        icon_emoji_id: Optional[int] = None,
-    ) -> "types.ForumTopicCreated":
+        icon_color: int | None = None,
+        icon_emoji_id: int | None = None,
+    ) -> types.ForumTopicCreated:
         """Create a new forum topic.
 
         .. include:: /_includes/usable-by/users-bots.rst

--- a/hydrogram/methods/chats/create_group.py
+++ b/hydrogram/methods/chats/create_group.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw, types
@@ -25,10 +25,10 @@ from hydrogram import raw, types
 
 class CreateGroup:
     async def create_group(
-        self: "hydrogram.Client",
+        self: hydrogram.Client,
         title: str,
-        users: Union[Union[int, str], list[Union[int, str]]],
-    ) -> "types.Chat":
+        users: int | str | list[int | str],
+    ) -> types.Chat:
         """Create a new basic group.
 
         .. note::

--- a/hydrogram/methods/chats/delete_channel.py
+++ b/hydrogram/methods/chats/delete_channel.py
@@ -17,14 +17,14 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
 
 
 class DeleteChannel:
-    async def delete_channel(self: "hydrogram.Client", chat_id: Union[int, str]) -> bool:
+    async def delete_channel(self: hydrogram.Client, chat_id: int | str) -> bool:
         """Delete a channel.
 
         .. include:: /_includes/usable-by/users.rst

--- a/hydrogram/methods/chats/delete_chat_photo.py
+++ b/hydrogram/methods/chats/delete_chat_photo.py
@@ -17,14 +17,14 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
 
 
 class DeleteChatPhoto:
-    async def delete_chat_photo(self: "hydrogram.Client", chat_id: Union[int, str]) -> bool:
+    async def delete_chat_photo(self: hydrogram.Client, chat_id: int | str) -> bool:
         """Delete a chat photo.
 
         You must be an administrator in the chat for this to work and must have the appropriate admin rights.

--- a/hydrogram/methods/chats/delete_forum_topic.py
+++ b/hydrogram/methods/chats/delete_forum_topic.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
@@ -24,7 +24,7 @@ from hydrogram import raw
 
 class DeleteForumTopic:
     async def delete_forum_topic(
-        self: "hydrogram.Client", chat_id: Union[int, str], topic_id: int
+        self: hydrogram.Client, chat_id: int | str, topic_id: int
     ) -> bool:
         """Delete a forum topic.
 

--- a/hydrogram/methods/chats/delete_supergroup.py
+++ b/hydrogram/methods/chats/delete_supergroup.py
@@ -17,14 +17,14 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
 
 
 class DeleteSupergroup:
-    async def delete_supergroup(self: "hydrogram.Client", chat_id: Union[int, str]) -> bool:
+    async def delete_supergroup(self: hydrogram.Client, chat_id: int | str) -> bool:
         """Delete a supergroup.
 
         .. include:: /_includes/usable-by/users.rst

--- a/hydrogram/methods/chats/delete_user_history.py
+++ b/hydrogram/methods/chats/delete_user_history.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
@@ -25,9 +25,9 @@ from hydrogram import raw
 
 class DeleteUserHistory:
     async def delete_user_history(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
-        user_id: Union[int, str],
+        self: hydrogram.Client,
+        chat_id: int | str,
+        user_id: int | str,
     ) -> bool:
         """Delete all messages sent by a certain user in a supergroup.
 

--- a/hydrogram/methods/chats/edit_forum_topic.py
+++ b/hydrogram/methods/chats/edit_forum_topic.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional, Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
@@ -24,11 +24,11 @@ from hydrogram import raw
 
 class EditForumTopic:
     async def edit_forum_topic(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
+        self: hydrogram.Client,
+        chat_id: int | str,
         topic_id: int,
-        title: Optional[str] = None,
-        icon_emoji_id: Optional[int] = None,
+        title: str | None = None,
+        icon_emoji_id: int | None = None,
     ) -> bool:
         """Edit a forum topic.
 

--- a/hydrogram/methods/chats/edit_general_topic.py
+++ b/hydrogram/methods/chats/edit_general_topic.py
@@ -16,16 +16,14 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
 
 
 class EditGeneralTopic:
-    async def edit_general_topic(
-        self: "hydrogram.Client", chat_id: Union[int, str], title: str
-    ) -> bool:
+    async def edit_general_topic(self: hydrogram.Client, chat_id: int | str, title: str) -> bool:
         """Edit a general forum topic.
 
         .. include:: /_includes/usable-by/users-bots.rst

--- a/hydrogram/methods/chats/get_chat.py
+++ b/hydrogram/methods/chats/get_chat.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw, types, utils
@@ -25,8 +25,8 @@ from hydrogram import raw, types, utils
 
 class GetChat:
     async def get_chat(
-        self: "hydrogram.Client", chat_id: Union[int, str]
-    ) -> Union["types.Chat", "types.ChatPreview"]:
+        self: hydrogram.Client, chat_id: int | str
+    ) -> types.Chat | types.ChatPreview:
         """Get up to date information about a chat.
 
         Information include current name of the user for one-on-one conversations, current username of a user, group or

--- a/hydrogram/methods/chats/get_chat_event_log.py
+++ b/hydrogram/methods/chats/get_chat_event_log.py
@@ -17,23 +17,27 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from collections.abc import AsyncGenerator
-from typing import Optional, Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import hydrogram
 from hydrogram import raw, types
 
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
 
 class GetChatEventLog:
     async def get_chat_event_log(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
+        self: hydrogram.Client,
+        chat_id: int | str,
         query: str = "",
         offset_id: int = 0,
         limit: int = 0,
-        filters: "types.ChatEventFilter" = None,
-        user_ids: Optional[list[Union[int, str]]] = None,
-    ) -> Optional[AsyncGenerator["types.ChatEvent", None]]:
+        filters: types.ChatEventFilter = None,
+        user_ids: list[int | str] | None = None,
+    ) -> AsyncGenerator[types.ChatEvent, None] | None:
         """Get the actions taken by chat members and administrators in the last 48h.
 
         Only available for supergroups and channels. Requires administrator rights.

--- a/hydrogram/methods/chats/get_chat_member.py
+++ b/hydrogram/methods/chats/get_chat_member.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw, types
@@ -26,8 +26,8 @@ from hydrogram.errors import UserNotParticipant
 
 class GetChatMember:
     async def get_chat_member(
-        self: "hydrogram.Client", chat_id: Union[int, str], user_id: Union[int, str]
-    ) -> "types.ChatMember":
+        self: hydrogram.Client, chat_id: int | str, user_id: int | str
+    ) -> types.ChatMember:
         """Get information about one member of a chat.
 
         .. include:: /_includes/usable-by/users-bots.rst

--- a/hydrogram/methods/chats/get_chat_members.py
+++ b/hydrogram/methods/chats/get_chat_members.py
@@ -17,21 +17,25 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import logging
-from collections.abc import AsyncGenerator
-from typing import Optional, Union
+from typing import TYPE_CHECKING
 
 import hydrogram
 from hydrogram import enums, raw, types
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
 
 log = logging.getLogger(__name__)
 
 
 async def get_chunk(
-    client: "hydrogram.Client",
-    chat_id: Union[int, str],
+    client: hydrogram.Client,
+    chat_id: int | str,
     offset: int,
-    filter: "enums.ChatMembersFilter",
+    filter: enums.ChatMembersFilter,
     limit: int,
     query: str,
 ):
@@ -63,12 +67,12 @@ async def get_chunk(
 
 class GetChatMembers:
     async def get_chat_members(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
+        self: hydrogram.Client,
+        chat_id: int | str,
         query: str = "",
         limit: int = 0,
-        filter: "enums.ChatMembersFilter" = enums.ChatMembersFilter.SEARCH,
-    ) -> Optional[AsyncGenerator["types.ChatMember", None]]:
+        filter: enums.ChatMembersFilter = enums.ChatMembersFilter.SEARCH,
+    ) -> AsyncGenerator[types.ChatMember, None] | None:
         """Get the members list of a chat.
 
         A chat can be either a basic group, a supergroup or a channel.

--- a/hydrogram/methods/chats/get_chat_members_count.py
+++ b/hydrogram/methods/chats/get_chat_members_count.py
@@ -17,14 +17,14 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
 
 
 class GetChatMembersCount:
-    async def get_chat_members_count(self: "hydrogram.Client", chat_id: Union[int, str]) -> int:
+    async def get_chat_members_count(self: hydrogram.Client, chat_id: int | str) -> int:
         """Get the number of members in a chat.
 
         .. include:: /_includes/usable-by/users-bots.rst

--- a/hydrogram/methods/chats/get_chat_online_count.py
+++ b/hydrogram/methods/chats/get_chat_online_count.py
@@ -17,14 +17,14 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
 
 
 class GetChatOnlineCount:
-    async def get_chat_online_count(self: "hydrogram.Client", chat_id: Union[int, str]) -> int:
+    async def get_chat_online_count(self: hydrogram.Client, chat_id: int | str) -> int:
         """Get the number of members that are currently online in a chat.
 
         .. include:: /_includes/usable-by/users.rst

--- a/hydrogram/methods/chats/get_dialogs.py
+++ b/hydrogram/methods/chats/get_dialogs.py
@@ -17,17 +17,21 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from collections.abc import AsyncGenerator
-from typing import Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import hydrogram
 from hydrogram import raw, types, utils
 
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
 
 class GetDialogs:
     async def get_dialogs(
-        self: "hydrogram.Client", limit: int = 0
-    ) -> Optional[AsyncGenerator["types.Dialog", None]]:
+        self: hydrogram.Client, limit: int = 0
+    ) -> AsyncGenerator[types.Dialog, None] | None:
         """Get a user's dialogs sequentially.
 
         .. include:: /_includes/usable-by/users.rst

--- a/hydrogram/methods/chats/get_forum_topics.py
+++ b/hydrogram/methods/chats/get_forum_topics.py
@@ -16,20 +16,24 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import logging
-from collections.abc import AsyncGenerator
-from typing import Optional, Union
+from typing import TYPE_CHECKING
 
 import hydrogram
 from hydrogram import raw, types
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
 
 log = logging.getLogger(__name__)
 
 
 class GetForumTopics:
     async def get_forum_topics(
-        self: "hydrogram.Client", chat_id: Union[int, str], limit: int = 0
-    ) -> Optional[AsyncGenerator["types.ForumTopic", None]]:
+        self: hydrogram.Client, chat_id: int | str, limit: int = 0
+    ) -> AsyncGenerator[types.ForumTopic, None] | None:
         """Get one or more topic from a chat.
 
         .. include:: /_includes/usable-by/users.rst

--- a/hydrogram/methods/chats/get_forum_topics_by_id.py
+++ b/hydrogram/methods/chats/get_forum_topics_by_id.py
@@ -16,20 +16,24 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import logging
-from collections.abc import Iterable
-from typing import Union
+from typing import TYPE_CHECKING
 
 import hydrogram
 from hydrogram import raw, types
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 log = logging.getLogger(__name__)
 
 
 class GetForumTopicsByID:
     async def get_forum_topics_by_id(
-        self: "hydrogram.Client", chat_id: Union[int, str], topic_ids: Union[int, Iterable[int]]
-    ) -> Union["types.ForumTopic", list["types.ForumTopic"]]:
+        self: hydrogram.Client, chat_id: int | str, topic_ids: int | Iterable[int]
+    ) -> types.ForumTopic | list[types.ForumTopic]:
         """Get one or more topic from a chat by using topic identifiers.
 
         .. include:: /_includes/usable-by/users.rst

--- a/hydrogram/methods/chats/get_send_as_chats.py
+++ b/hydrogram/methods/chats/get_send_as_chats.py
@@ -17,16 +17,14 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw, types
 
 
 class GetSendAsChats:
-    async def get_send_as_chats(
-        self: "hydrogram.Client", chat_id: Union[int, str]
-    ) -> list["types.Chat"]:
+    async def get_send_as_chats(self: hydrogram.Client, chat_id: int | str) -> list[types.Chat]:
         """Get the list of "send_as" chats available.
 
         .. include:: /_includes/usable-by/users.rst

--- a/hydrogram/methods/chats/hide_general_topic.py
+++ b/hydrogram/methods/chats/hide_general_topic.py
@@ -16,14 +16,14 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
 
 
 class HideGeneralTopic:
-    async def hide_general_topic(self: "hydrogram.Client", chat_id: Union[int, str]) -> bool:
+    async def hide_general_topic(self: hydrogram.Client, chat_id: int | str) -> bool:
         """hide a general forum topic.
 
         .. include:: /_includes/usable-by/users-bots.rst

--- a/hydrogram/methods/chats/join_chat.py
+++ b/hydrogram/methods/chats/join_chat.py
@@ -17,14 +17,14 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw, types
 
 
 class JoinChat:
-    async def join_chat(self: "hydrogram.Client", chat_id: Union[int, str]) -> "types.Chat":
+    async def join_chat(self: hydrogram.Client, chat_id: int | str) -> types.Chat:
         """Join a group chat or channel.
 
         .. include:: /_includes/usable-by/users.rst

--- a/hydrogram/methods/chats/leave_chat.py
+++ b/hydrogram/methods/chats/leave_chat.py
@@ -17,14 +17,14 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
 
 
 class LeaveChat:
-    async def leave_chat(self: "hydrogram.Client", chat_id: Union[int, str], delete: bool = False):
+    async def leave_chat(self: hydrogram.Client, chat_id: int | str, delete: bool = False):
         """Leave a group chat or channel.
 
         .. include:: /_includes/usable-by/users-bots.rst

--- a/hydrogram/methods/chats/mark_chat_unread.py
+++ b/hydrogram/methods/chats/mark_chat_unread.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
@@ -25,8 +25,8 @@ from hydrogram import raw
 
 class MarkChatUnread:
     async def mark_chat_unread(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
+        self: hydrogram.Client,
+        chat_id: int | str,
     ) -> bool:
         """Mark a chat as unread.
 

--- a/hydrogram/methods/chats/pin_chat_message.py
+++ b/hydrogram/methods/chats/pin_chat_message.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw, types
@@ -25,12 +25,12 @@ from hydrogram import raw, types
 
 class PinChatMessage:
     async def pin_chat_message(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
+        self: hydrogram.Client,
+        chat_id: int | str,
         message_id: int,
         disable_notification: bool = False,
         both_sides: bool = False,
-    ) -> "types.Message":
+    ) -> types.Message:
         """Pin a message in a group, channel or your own chat.
         You must be an administrator in the chat for this to work and must have the "can_pin_messages" admin right in
         the supergroup or "can_edit_messages" admin right in the channel.

--- a/hydrogram/methods/chats/promote_chat_member.py
+++ b/hydrogram/methods/chats/promote_chat_member.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import errors, raw, types
@@ -25,10 +25,10 @@ from hydrogram import errors, raw, types
 
 class PromoteChatMember:
     async def promote_chat_member(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
-        user_id: Union[int, str],
-        privileges: "types.ChatPrivileges" = None,
+        self: hydrogram.Client,
+        chat_id: int | str,
+        user_id: int | str,
+        privileges: types.ChatPrivileges = None,
     ) -> bool:
         """Promote or demote a user in a supergroup or a channel.
 

--- a/hydrogram/methods/chats/reopen_forum_topic.py
+++ b/hydrogram/methods/chats/reopen_forum_topic.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
@@ -24,7 +24,7 @@ from hydrogram import raw
 
 class ReopenForumTopic:
     async def reopen_forum_topic(
-        self: "hydrogram.Client", chat_id: Union[int, str], topic_id: int
+        self: hydrogram.Client, chat_id: int | str, topic_id: int
     ) -> bool:
         """Reopen a forum topic.
 

--- a/hydrogram/methods/chats/reopen_general_topic.py
+++ b/hydrogram/methods/chats/reopen_general_topic.py
@@ -16,14 +16,14 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
 
 
 class ReopenGeneralTopic:
-    async def reopen_general_topic(self: "hydrogram.Client", chat_id: Union[int, str]) -> bool:
+    async def reopen_general_topic(self: hydrogram.Client, chat_id: int | str) -> bool:
         """Reopen a general forum topic.
 
         .. include:: /_includes/usable-by/users-bots.rst

--- a/hydrogram/methods/chats/restrict_chat_member.py
+++ b/hydrogram/methods/chats/restrict_chat_member.py
@@ -17,21 +17,25 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from datetime import datetime
-from typing import Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import hydrogram
 from hydrogram import raw, types, utils
 
+if TYPE_CHECKING:
+    from datetime import datetime
+
 
 class RestrictChatMember:
     async def restrict_chat_member(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
-        user_id: Union[int, str],
-        permissions: "types.ChatPermissions",
+        self: hydrogram.Client,
+        chat_id: int | str,
+        user_id: int | str,
+        permissions: types.ChatPermissions,
         until_date: datetime = utils.zero_datetime(),
-    ) -> "types.Chat":
+    ) -> types.Chat:
         """Restrict a user in a supergroup.
 
         You must be an administrator in the supergroup for this to work and must have the appropriate admin rights.

--- a/hydrogram/methods/chats/set_administrator_title.py
+++ b/hydrogram/methods/chats/set_administrator_title.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
@@ -25,9 +25,9 @@ from hydrogram import raw
 
 class SetAdministratorTitle:
     async def set_administrator_title(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
-        user_id: Union[int, str],
+        self: hydrogram.Client,
+        chat_id: int | str,
+        user_id: int | str,
         title: str,
     ) -> bool:
         """Set a custom title (rank) to an administrator of a supergroup.

--- a/hydrogram/methods/chats/set_chat_description.py
+++ b/hydrogram/methods/chats/set_chat_description.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
@@ -25,7 +25,7 @@ from hydrogram import raw
 
 class SetChatDescription:
     async def set_chat_description(
-        self: "hydrogram.Client", chat_id: Union[int, str], description: str
+        self: hydrogram.Client, chat_id: int | str, description: str
     ) -> bool:
         """Change the description of a supergroup or a channel.
         You must be an administrator in the chat for this to work and must have the appropriate admin rights.

--- a/hydrogram/methods/chats/set_chat_permissions.py
+++ b/hydrogram/methods/chats/set_chat_permissions.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw, types
@@ -25,10 +25,10 @@ from hydrogram import raw, types
 
 class SetChatPermissions:
     async def set_chat_permissions(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
-        permissions: "types.ChatPermissions",
-    ) -> "types.Chat":
+        self: hydrogram.Client,
+        chat_id: int | str,
+        permissions: types.ChatPermissions,
+    ) -> types.Chat:
         """Set default chat permissions for all members.
 
         You must be an administrator in the group or a supergroup for this to work and must have the

--- a/hydrogram/methods/chats/set_chat_photo.py
+++ b/hydrogram/methods/chats/set_chat_photo.py
@@ -17,8 +17,10 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 from pathlib import Path
-from typing import BinaryIO, Optional, Union
+from typing import BinaryIO
 
 import hydrogram
 from hydrogram import raw, utils
@@ -27,12 +29,12 @@ from hydrogram.file_id import FileType
 
 class SetChatPhoto:
     async def set_chat_photo(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
+        self: hydrogram.Client,
+        chat_id: int | str,
         *,
-        photo: Optional[Union[str, BinaryIO]] = None,
-        video: Optional[Union[str, BinaryIO]] = None,
-        video_start_ts: Optional[float] = None,
+        photo: str | BinaryIO | None = None,
+        video: str | BinaryIO | None = None,
+        video_start_ts: float | None = None,
     ) -> bool:
         """Set a new chat photo or video (H.264/MPEG-4 AVC video, max 5 seconds).
 

--- a/hydrogram/methods/chats/set_chat_protected_content.py
+++ b/hydrogram/methods/chats/set_chat_protected_content.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
@@ -25,7 +25,7 @@ from hydrogram import raw
 
 class SetChatProtectedContent:
     async def set_chat_protected_content(
-        self: "hydrogram.Client", chat_id: Union[int, str], enabled: bool
+        self: hydrogram.Client, chat_id: int | str, enabled: bool
     ) -> bool:
         """Set the chat protected content setting.
 

--- a/hydrogram/methods/chats/set_chat_title.py
+++ b/hydrogram/methods/chats/set_chat_title.py
@@ -17,16 +17,14 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
 
 
 class SetChatTitle:
-    async def set_chat_title(
-        self: "hydrogram.Client", chat_id: Union[int, str], title: str
-    ) -> bool:
+    async def set_chat_title(self: hydrogram.Client, chat_id: int | str, title: str) -> bool:
         """Change the title of a chat.
         Titles can't be changed for private chats.
         You must be an administrator in the chat for this to work and must have the appropriate admin rights.

--- a/hydrogram/methods/chats/set_chat_username.py
+++ b/hydrogram/methods/chats/set_chat_username.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional, Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
@@ -25,7 +25,7 @@ from hydrogram import raw
 
 class SetChatUsername:
     async def set_chat_username(
-        self: "hydrogram.Client", chat_id: Union[int, str], username: Optional[str]
+        self: hydrogram.Client, chat_id: int | str, username: str | None
     ) -> bool:
         """Set a channel or a supergroup username.
 

--- a/hydrogram/methods/chats/set_send_as_chat.py
+++ b/hydrogram/methods/chats/set_send_as_chat.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
@@ -25,9 +25,9 @@ from hydrogram import raw
 
 class SetSendAsChat:
     async def set_send_as_chat(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
-        send_as_chat_id: Union[int, str],
+        self: hydrogram.Client,
+        chat_id: int | str,
+        send_as_chat_id: int | str,
     ) -> bool:
         """Set the default "send_as" chat for a chat.
 

--- a/hydrogram/methods/chats/set_slow_mode.py
+++ b/hydrogram/methods/chats/set_slow_mode.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional, Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
@@ -25,7 +25,7 @@ from hydrogram import raw
 
 class SetSlowMode:
     async def set_slow_mode(
-        self: "hydrogram.Client", chat_id: Union[int, str], seconds: Optional[int]
+        self: hydrogram.Client, chat_id: int | str, seconds: int | None
     ) -> bool:
         """Set the slow mode interval for a chat.
 

--- a/hydrogram/methods/chats/unarchive_chats.py
+++ b/hydrogram/methods/chats/unarchive_chats.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
@@ -25,8 +25,8 @@ from hydrogram import raw
 
 class UnarchiveChats:
     async def unarchive_chats(
-        self: "hydrogram.Client",
-        chat_ids: Union[int, str, list[Union[int, str]]],
+        self: hydrogram.Client,
+        chat_ids: int | str | list[int | str],
     ) -> bool:
         """Unarchive one or more chats.
 

--- a/hydrogram/methods/chats/unban_chat_member.py
+++ b/hydrogram/methods/chats/unban_chat_member.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
@@ -25,7 +25,7 @@ from hydrogram import raw
 
 class UnbanChatMember:
     async def unban_chat_member(
-        self: "hydrogram.Client", chat_id: Union[int, str], user_id: Union[int, str]
+        self: hydrogram.Client, chat_id: int | str, user_id: int | str
     ) -> bool:
         """Unban a previously banned user in a supergroup or channel.
         The user will **not** return to the group or channel automatically, but will be able to join via link, etc.

--- a/hydrogram/methods/chats/unhide_general_topic.py
+++ b/hydrogram/methods/chats/unhide_general_topic.py
@@ -16,14 +16,14 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
 
 
 class UnhideGeneralTopic:
-    async def unhide_general_topic(self: "hydrogram.Client", chat_id: Union[int, str]) -> bool:
+    async def unhide_general_topic(self: hydrogram.Client, chat_id: int | str) -> bool:
         """unhide a general forum topic.
 
         .. include:: /_includes/usable-by/users-bots.rst

--- a/hydrogram/methods/chats/unpin_all_chat_messages.py
+++ b/hydrogram/methods/chats/unpin_all_chat_messages.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
@@ -25,8 +25,8 @@ from hydrogram import raw
 
 class UnpinAllChatMessages:
     async def unpin_all_chat_messages(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
+        self: hydrogram.Client,
+        chat_id: int | str,
     ) -> bool:
         """Use this method to clear the list of pinned messages in a chat.
         If the chat is not a private chat, the bot must be an administrator in the chat for this to work and must have

--- a/hydrogram/methods/chats/unpin_chat_message.py
+++ b/hydrogram/methods/chats/unpin_chat_message.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
@@ -25,7 +25,7 @@ from hydrogram import raw
 
 class UnpinChatMessage:
     async def unpin_chat_message(
-        self: "hydrogram.Client", chat_id: Union[int, str], message_id: int = 0
+        self: hydrogram.Client, chat_id: int | str, message_id: int = 0
     ) -> bool:
         """Unpin a message in a group, channel or your own chat.
         You must be an administrator in the chat for this to work and must have the "can_pin_messages" admin

--- a/hydrogram/methods/contacts/add_contact.py
+++ b/hydrogram/methods/contacts/add_contact.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw, types
@@ -25,8 +25,8 @@ from hydrogram import raw, types
 
 class AddContact:
     async def add_contact(
-        self: "hydrogram.Client",
-        user_id: Union[int, str],
+        self: hydrogram.Client,
+        user_id: int | str,
         first_name: str,
         last_name: str = "",
         phone_number: str = "",

--- a/hydrogram/methods/contacts/delete_contacts.py
+++ b/hydrogram/methods/contacts/delete_contacts.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw, types
@@ -25,8 +25,8 @@ from hydrogram import raw, types
 
 class DeleteContacts:
     async def delete_contacts(
-        self: "hydrogram.Client", user_ids: Union[int, str, list[Union[int, str]]]
-    ) -> Union["types.User", list["types.User"], None]:
+        self: hydrogram.Client, user_ids: int | str | list[int | str]
+    ) -> types.User | list[types.User] | None:
         """Delete contacts from your Telegram address book.
 
         .. include:: /_includes/usable-by/users.rst

--- a/hydrogram/methods/invite_links/approve_all_chat_join_requests.py
+++ b/hydrogram/methods/invite_links/approve_all_chat_join_requests.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional, Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
@@ -25,7 +25,7 @@ from hydrogram import raw
 
 class ApproveAllChatJoinRequests:
     async def approve_all_chat_join_requests(
-        self: "hydrogram.Client", chat_id: Union[int, str], invite_link: Optional[str] = None
+        self: hydrogram.Client, chat_id: int | str, invite_link: str | None = None
     ) -> bool:
         """Approve all pending join requests in a chat.
 

--- a/hydrogram/methods/invite_links/approve_chat_join_request.py
+++ b/hydrogram/methods/invite_links/approve_chat_join_request.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
@@ -25,8 +25,8 @@ from hydrogram import raw
 
 class ApproveChatJoinRequest:
     async def approve_chat_join_request(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
+        self: hydrogram.Client,
+        chat_id: int | str,
         user_id: int,
     ) -> bool:
         """Approve a chat join request.

--- a/hydrogram/methods/invite_links/create_chat_invite_link.py
+++ b/hydrogram/methods/invite_links/create_chat_invite_link.py
@@ -17,22 +17,26 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from datetime import datetime
-from typing import Optional, Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import hydrogram
 from hydrogram import raw, types, utils
 
+if TYPE_CHECKING:
+    from datetime import datetime
+
 
 class CreateChatInviteLink:
     async def create_chat_invite_link(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
-        name: Optional[str] = None,
-        expire_date: Optional[datetime] = None,
-        member_limit: Optional[int] = None,
-        creates_join_request: Optional[bool] = None,
-    ) -> "types.ChatInviteLink":
+        self: hydrogram.Client,
+        chat_id: int | str,
+        name: str | None = None,
+        expire_date: datetime | None = None,
+        member_limit: int | None = None,
+        creates_join_request: bool | None = None,
+    ) -> types.ChatInviteLink:
         """Create an additional invite link for a chat.
 
         You must be an administrator in the chat for this to work and must have the appropriate admin rights.

--- a/hydrogram/methods/invite_links/decline_all_chat_join_requests.py
+++ b/hydrogram/methods/invite_links/decline_all_chat_join_requests.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional, Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
@@ -25,7 +25,7 @@ from hydrogram import raw
 
 class DeclineAllChatJoinRequests:
     async def decline_all_chat_join_requests(
-        self: "hydrogram.Client", chat_id: Union[int, str], invite_link: Optional[str] = None
+        self: hydrogram.Client, chat_id: int | str, invite_link: str | None = None
     ) -> bool:
         """Decline all pending join requests in a chat.
 

--- a/hydrogram/methods/invite_links/decline_chat_join_request.py
+++ b/hydrogram/methods/invite_links/decline_chat_join_request.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
@@ -25,8 +25,8 @@ from hydrogram import raw
 
 class DeclineChatJoinRequest:
     async def decline_chat_join_request(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
+        self: hydrogram.Client,
+        chat_id: int | str,
         user_id: int,
     ) -> bool:
         """Decline a chat join request.

--- a/hydrogram/methods/invite_links/delete_chat_admin_invite_links.py
+++ b/hydrogram/methods/invite_links/delete_chat_admin_invite_links.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
@@ -25,9 +25,9 @@ from hydrogram import raw
 
 class DeleteChatAdminInviteLinks:
     async def delete_chat_admin_invite_links(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
-        admin_id: Union[int, str],
+        self: hydrogram.Client,
+        chat_id: int | str,
+        admin_id: int | str,
     ) -> bool:
         """Delete all revoked invite links of an administrator.
 

--- a/hydrogram/methods/invite_links/delete_chat_invite_link.py
+++ b/hydrogram/methods/invite_links/delete_chat_invite_link.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
@@ -25,8 +25,8 @@ from hydrogram import raw
 
 class DeleteChatInviteLink:
     async def delete_chat_invite_link(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
+        self: hydrogram.Client,
+        chat_id: int | str,
         invite_link: str,
     ) -> bool:
         """Delete an already revoked invite link.

--- a/hydrogram/methods/invite_links/edit_chat_invite_link.py
+++ b/hydrogram/methods/invite_links/edit_chat_invite_link.py
@@ -17,23 +17,27 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from datetime import datetime
-from typing import Optional, Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import hydrogram
 from hydrogram import raw, types, utils
 
+if TYPE_CHECKING:
+    from datetime import datetime
+
 
 class EditChatInviteLink:
     async def edit_chat_invite_link(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
+        self: hydrogram.Client,
+        chat_id: int | str,
         invite_link: str,
-        name: Optional[str] = None,
-        expire_date: Optional[datetime] = None,
-        member_limit: Optional[int] = None,
-        creates_join_request: Optional[bool] = None,
-    ) -> "types.ChatInviteLink":
+        name: str | None = None,
+        expire_date: datetime | None = None,
+        member_limit: int | None = None,
+        creates_join_request: bool | None = None,
+    ) -> types.ChatInviteLink:
         """Edit a non-primary invite link.
 
         You must be an administrator in the chat for this to work and must have the appropriate admin rights.

--- a/hydrogram/methods/invite_links/export_chat_invite_link.py
+++ b/hydrogram/methods/invite_links/export_chat_invite_link.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw, types
@@ -25,9 +25,9 @@ from hydrogram import raw, types
 
 class ExportChatInviteLink:
     async def export_chat_invite_link(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
-    ) -> "types.ChatInviteLink":
+        self: hydrogram.Client,
+        chat_id: int | str,
+    ) -> types.ChatInviteLink:
         """Generate a new primary invite link for a chat; any previously generated primary link is revoked.
 
         You must be an administrator in the chat for this to work and must have the appropriate admin rights.

--- a/hydrogram/methods/invite_links/get_chat_admin_invite_links.py
+++ b/hydrogram/methods/invite_links/get_chat_admin_invite_links.py
@@ -17,21 +17,25 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from collections.abc import AsyncGenerator
-from typing import Optional, Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import hydrogram
 from hydrogram import raw, types
 
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
 
 class GetChatAdminInviteLinks:
     async def get_chat_admin_invite_links(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
-        admin_id: Union[int, str],
+        self: hydrogram.Client,
+        chat_id: int | str,
+        admin_id: int | str,
         revoked: bool = False,
         limit: int = 0,
-    ) -> Optional[AsyncGenerator["types.ChatInviteLink", None]]:
+    ) -> AsyncGenerator[types.ChatInviteLink, None] | None:
         """Get the invite links created by an administrator in a chat.
 
         .. note::

--- a/hydrogram/methods/invite_links/get_chat_admin_invite_links_count.py
+++ b/hydrogram/methods/invite_links/get_chat_admin_invite_links_count.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
@@ -25,9 +25,9 @@ from hydrogram import raw
 
 class GetChatAdminInviteLinksCount:
     async def get_chat_admin_invite_links_count(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
-        admin_id: Union[int, str],
+        self: hydrogram.Client,
+        chat_id: int | str,
+        admin_id: int | str,
         revoked: bool = False,
     ) -> int:
         """Get the count of the invite links created by an administrator in a chat.

--- a/hydrogram/methods/invite_links/get_chat_admins_with_invite_links.py
+++ b/hydrogram/methods/invite_links/get_chat_admins_with_invite_links.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw, types
@@ -25,8 +25,8 @@ from hydrogram import raw, types
 
 class GetChatAdminsWithInviteLinks:
     async def get_chat_admins_with_invite_links(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
+        self: hydrogram.Client,
+        chat_id: int | str,
     ):
         """Get the list of the administrators that have exported invite links in a chat.
 

--- a/hydrogram/methods/invite_links/get_chat_invite_link.py
+++ b/hydrogram/methods/invite_links/get_chat_invite_link.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw, types
@@ -25,10 +25,10 @@ from hydrogram import raw, types
 
 class GetChatInviteLink:
     async def get_chat_invite_link(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
+        self: hydrogram.Client,
+        chat_id: int | str,
         invite_link: str,
-    ) -> "types.ChatInviteLink":
+    ) -> types.ChatInviteLink:
         """Get detailed information about a chat invite link.
 
         .. include:: /_includes/usable-by/users-bots.rst

--- a/hydrogram/methods/invite_links/get_chat_invite_link_joiners.py
+++ b/hydrogram/methods/invite_links/get_chat_invite_link_joiners.py
@@ -17,20 +17,24 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from collections.abc import AsyncGenerator
-from typing import Optional, Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import hydrogram
 from hydrogram import raw, types
 
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
 
 class GetChatInviteLinkJoiners:
     async def get_chat_invite_link_joiners(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
+        self: hydrogram.Client,
+        chat_id: int | str,
         invite_link: str,
         limit: int = 0,
-    ) -> Optional[AsyncGenerator["types.ChatJoiner", None]]:
+    ) -> AsyncGenerator[types.ChatJoiner, None] | None:
         """Get the members who joined the chat with the invite link.
 
         .. include:: /_includes/usable-by/users.rst

--- a/hydrogram/methods/invite_links/get_chat_invite_link_joiners_count.py
+++ b/hydrogram/methods/invite_links/get_chat_invite_link_joiners_count.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
@@ -25,7 +25,7 @@ from hydrogram import raw
 
 class GetChatInviteLinkJoinersCount:
     async def get_chat_invite_link_joiners_count(
-        self: "hydrogram.Client", chat_id: Union[int, str], invite_link: str
+        self: hydrogram.Client, chat_id: int | str, invite_link: str
     ) -> int:
         """Get the count of the members who joined the chat with the invite link.
 

--- a/hydrogram/methods/invite_links/get_chat_join_requests.py
+++ b/hydrogram/methods/invite_links/get_chat_join_requests.py
@@ -17,20 +17,24 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from collections.abc import AsyncGenerator
-from typing import Optional, Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import hydrogram
 from hydrogram import raw, types
 
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
 
 class GetChatJoinRequests:
     async def get_chat_join_requests(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
+        self: hydrogram.Client,
+        chat_id: int | str,
         limit: int = 0,
         query: str = "",
-    ) -> Optional[AsyncGenerator["types.ChatJoiner", None]]:
+    ) -> AsyncGenerator[types.ChatJoiner, None] | None:
         """Get the pending join requests of a chat.
 
         .. include:: /_includes/usable-by/users.rst

--- a/hydrogram/methods/invite_links/revoke_chat_invite_link.py
+++ b/hydrogram/methods/invite_links/revoke_chat_invite_link.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw, types
@@ -25,10 +25,10 @@ from hydrogram import raw, types
 
 class RevokeChatInviteLink:
     async def revoke_chat_invite_link(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
+        self: hydrogram.Client,
+        chat_id: int | str,
         invite_link: str,
-    ) -> "types.ChatInviteLink":
+    ) -> types.ChatInviteLink:
         """Revoke a previously created invite link.
 
         If the primary link is revoked, a new link is automatically generated.

--- a/hydrogram/methods/messages/copy_media_group.py
+++ b/hydrogram/methods/messages/copy_media_group.py
@@ -17,26 +17,30 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from datetime import datetime
-from typing import Optional, Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import hydrogram
 from hydrogram import raw, types, utils
 
+if TYPE_CHECKING:
+    from datetime import datetime
+
 
 class CopyMediaGroup:
     async def copy_media_group(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
-        from_chat_id: Union[int, str],
+        self: hydrogram.Client,
+        chat_id: int | str,
+        from_chat_id: int | str,
         message_id: int,
-        captions: Optional[Union[list[str], str]] = None,
+        captions: list[str] | str | None = None,
         *,
-        message_thread_id: Optional[int] = None,
-        disable_notification: Optional[bool] = None,
-        reply_to_message_id: Optional[int] = None,
-        schedule_date: Optional[datetime] = None,
-    ) -> list["types.Message"]:
+        message_thread_id: int | None = None,
+        disable_notification: bool | None = None,
+        reply_to_message_id: int | None = None,
+        schedule_date: datetime | None = None,
+    ) -> list[types.Message]:
         """Copy a media group by providing one of the message ids.
 
         .. include:: /_includes/usable-by/users-bots.rst

--- a/hydrogram/methods/messages/copy_message.py
+++ b/hydrogram/methods/messages/copy_message.py
@@ -17,38 +17,40 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-import logging
-from datetime import datetime
-from typing import Optional, Union
+from __future__ import annotations
 
-import hydrogram
-from hydrogram import enums, types
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+    import hydrogram
+    from hydrogram import enums, types
 
 log = logging.getLogger(__name__)
 
 
 class CopyMessage:
     async def copy_message(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
-        from_chat_id: Union[int, str],
+        self: hydrogram.Client,
+        chat_id: int | str,
+        from_chat_id: int | str,
         message_id: int,
-        caption: Optional[str] = None,
+        caption: str | None = None,
         *,
-        message_thread_id: Optional[int] = None,
-        parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: Optional[list["types.MessageEntity"]] = None,
-        disable_notification: Optional[bool] = None,
-        reply_to_message_id: Optional[int] = None,
-        schedule_date: Optional[datetime] = None,
-        protect_content: Optional[bool] = None,
-        reply_markup: Union[
-            "types.InlineKeyboardMarkup",
-            "types.ReplyKeyboardMarkup",
-            "types.ReplyKeyboardRemove",
-            "types.ForceReply",
-        ] = None,
-    ) -> "types.Message":
+        message_thread_id: int | None = None,
+        parse_mode: enums.ParseMode | None = None,
+        caption_entities: list[types.MessageEntity] | None = None,
+        disable_notification: bool | None = None,
+        reply_to_message_id: int | None = None,
+        schedule_date: datetime | None = None,
+        protect_content: bool | None = None,
+        reply_markup: types.InlineKeyboardMarkup
+        | types.ReplyKeyboardMarkup
+        | types.ReplyKeyboardRemove
+        | types.ForceReply = None,
+    ) -> types.Message:
         """Copy messages of any kind.
 
         The method is analogous to the method :meth:`~Client.forward_messages`, but the copied message doesn't have a

--- a/hydrogram/methods/messages/delete_messages.py
+++ b/hydrogram/methods/messages/delete_messages.py
@@ -17,18 +17,22 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from collections.abc import Iterable
-from typing import Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import hydrogram
 from hydrogram import raw
 
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
 
 class DeleteMessages:
     async def delete_messages(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
-        message_ids: Union[int, Iterable[int]],
+        self: hydrogram.Client,
+        chat_id: int | str,
+        message_ids: int | Iterable[int],
         revoke: bool = True,
     ) -> int:
         """Delete messages, including service messages.

--- a/hydrogram/methods/messages/download_media.py
+++ b/hydrogram/methods/messages/download_media.py
@@ -17,11 +17,13 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import asyncio
 import os
 from datetime import datetime
 from pathlib import Path
-from typing import BinaryIO, Callable, Optional, Union
+from typing import BinaryIO, Callable
 
 import hydrogram
 from hydrogram import types
@@ -32,14 +34,14 @@ DEFAULT_DOWNLOAD_DIR = "downloads/"
 
 class DownloadMedia:
     async def download_media(
-        self: "hydrogram.Client",
-        message: Union["types.Message", str],
+        self: hydrogram.Client,
+        message: types.Message | str,
         file_name: str = DEFAULT_DOWNLOAD_DIR,
         in_memory: bool = False,
         block: bool = True,
-        progress: Optional[Callable] = None,
+        progress: Callable | None = None,
         progress_args: tuple = (),
-    ) -> Optional[Union[str, BinaryIO]]:
+    ) -> str | BinaryIO | None:
         """Download the media from a message.
 
         .. include:: /_includes/usable-by/users-bots.rst

--- a/hydrogram/methods/messages/edit_inline_caption.py
+++ b/hydrogram/methods/messages/edit_inline_caption.py
@@ -17,10 +17,11 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
-import hydrogram
-from hydrogram import enums, types
+if TYPE_CHECKING:
+    import hydrogram
+    from hydrogram import enums, types
 
 
 class EditInlineCaption:

--- a/hydrogram/methods/messages/edit_inline_text.py
+++ b/hydrogram/methods/messages/edit_inline_text.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import enums, raw, types, utils
@@ -27,12 +27,12 @@ from .inline_session import get_session
 
 class EditInlineText:
     async def edit_inline_text(
-        self: "hydrogram.Client",
+        self: hydrogram.Client,
         inline_message_id: str,
         text: str,
-        parse_mode: Optional["enums.ParseMode"] = None,
-        disable_web_page_preview: Optional[bool] = None,
-        reply_markup: "types.InlineKeyboardMarkup" = None,
+        parse_mode: enums.ParseMode | None = None,
+        disable_web_page_preview: bool | None = None,
+        reply_markup: types.InlineKeyboardMarkup = None,
     ) -> bool:
         """Edit the text of inline messages.
 

--- a/hydrogram/methods/messages/edit_message_caption.py
+++ b/hydrogram/methods/messages/edit_message_caption.py
@@ -17,22 +17,25 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional, Union
+from __future__ import annotations
 
-import hydrogram
-from hydrogram import enums, types
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import hydrogram
+    from hydrogram import enums, types
 
 
 class EditMessageCaption:
     async def edit_message_caption(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
+        self: hydrogram.Client,
+        chat_id: int | str,
         message_id: int,
         caption: str,
-        parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: Optional[list["types.MessageEntity"]] = None,
-        reply_markup: "types.InlineKeyboardMarkup" = None,
-    ) -> "types.Message":
+        parse_mode: enums.ParseMode | None = None,
+        caption_entities: list[types.MessageEntity] | None = None,
+        reply_markup: types.InlineKeyboardMarkup = None,
+    ) -> types.Message:
         """Edit the caption of media messages.
 
         .. include:: /_includes/usable-by/users-bots.rst

--- a/hydrogram/methods/messages/edit_message_media.py
+++ b/hydrogram/methods/messages/edit_message_media.py
@@ -17,10 +17,11 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import io
 import re
 from pathlib import Path
-from typing import Optional, Union
 
 import hydrogram
 from hydrogram import raw, types, utils
@@ -29,13 +30,13 @@ from hydrogram.file_id import FileType
 
 class EditMessageMedia:
     async def edit_message_media(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
+        self: hydrogram.Client,
+        chat_id: int | str,
         message_id: int,
-        media: "types.InputMedia",
-        reply_markup: "types.InlineKeyboardMarkup" = None,
-        file_name: Optional[str] = None,
-    ) -> "types.Message":
+        media: types.InputMedia,
+        reply_markup: types.InlineKeyboardMarkup = None,
+        file_name: str | None = None,
+    ) -> types.Message:
         """Edit animation, audio, document, photo or video messages.
 
         If a message is a part of a message album, then it can be edited only to a photo or a video. Otherwise, the

--- a/hydrogram/methods/messages/edit_message_reply_markup.py
+++ b/hydrogram/methods/messages/edit_message_reply_markup.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw, types
@@ -25,11 +25,11 @@ from hydrogram import raw, types
 
 class EditMessageReplyMarkup:
     async def edit_message_reply_markup(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
+        self: hydrogram.Client,
+        chat_id: int | str,
         message_id: int,
-        reply_markup: "types.InlineKeyboardMarkup" = None,
-    ) -> "types.Message":
+        reply_markup: types.InlineKeyboardMarkup = None,
+    ) -> types.Message:
         """Edit only the reply markup of messages sent by the bot.
 
         .. include:: /_includes/usable-by/bots.rst

--- a/hydrogram/methods/messages/edit_message_text.py
+++ b/hydrogram/methods/messages/edit_message_text.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional, Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import enums, raw, types, utils
@@ -25,15 +25,15 @@ from hydrogram import enums, raw, types, utils
 
 class EditMessageText:
     async def edit_message_text(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
+        self: hydrogram.Client,
+        chat_id: int | str,
         message_id: int,
         text: str,
-        parse_mode: Optional["enums.ParseMode"] = None,
-        entities: Optional[list["types.MessageEntity"]] = None,
-        disable_web_page_preview: Optional[bool] = None,
-        reply_markup: "types.InlineKeyboardMarkup" = None,
-    ) -> "types.Message":
+        parse_mode: enums.ParseMode | None = None,
+        entities: list[types.MessageEntity] | None = None,
+        disable_web_page_preview: bool | None = None,
+        reply_markup: types.InlineKeyboardMarkup = None,
+    ) -> types.Message:
         """Edit the text of messages.
 
         .. include:: /_includes/usable-by/users-bots.rst

--- a/hydrogram/methods/messages/forward_messages.py
+++ b/hydrogram/methods/messages/forward_messages.py
@@ -17,26 +17,30 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from collections.abc import Iterable
-from datetime import datetime
-from typing import Optional, Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import hydrogram
 from hydrogram import raw, types, utils
 
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from datetime import datetime
+
 
 class ForwardMessages:
     async def forward_messages(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
-        from_chat_id: Union[int, str],
-        message_ids: Union[int, Iterable[int]],
+        self: hydrogram.Client,
+        chat_id: int | str,
+        from_chat_id: int | str,
+        message_ids: int | Iterable[int],
         *,
-        message_thread_id: Optional[int] = None,
-        disable_notification: Optional[bool] = None,
-        schedule_date: Optional[datetime] = None,
-        protect_content: Optional[bool] = None,
-    ) -> Union["types.Message", list["types.Message"]]:
+        message_thread_id: int | None = None,
+        disable_notification: bool | None = None,
+        schedule_date: datetime | None = None,
+        protect_content: bool | None = None,
+    ) -> types.Message | list[types.Message]:
         """Forward messages of any kind.
 
         .. include:: /_includes/usable-by/users-bots.rst

--- a/hydrogram/methods/messages/get_chat_history.py
+++ b/hydrogram/methods/messages/get_chat_history.py
@@ -17,18 +17,22 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from collections.abc import AsyncGenerator
-from datetime import datetime
-from typing import Optional, Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import hydrogram
 from hydrogram import raw, types, utils
 
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+    from datetime import datetime
+
 
 async def get_chunk(
     *,
-    client: "hydrogram.Client",
-    chat_id: Union[int, str],
+    client: hydrogram.Client,
+    chat_id: int | str,
     limit: int = 0,
     offset: int = 0,
     from_message_id: int = 0,
@@ -53,13 +57,13 @@ async def get_chunk(
 
 class GetChatHistory:
     async def get_chat_history(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
+        self: hydrogram.Client,
+        chat_id: int | str,
         limit: int = 0,
         offset: int = 0,
         offset_id: int = 0,
         offset_date: datetime = utils.zero_datetime(),
-    ) -> Optional[AsyncGenerator["types.Message", None]]:
+    ) -> AsyncGenerator[types.Message, None] | None:
         """Get messages from a chat history.
 
         The messages are returned in reverse chronological order.

--- a/hydrogram/methods/messages/get_chat_history_count.py
+++ b/hydrogram/methods/messages/get_chat_history_count.py
@@ -17,8 +17,9 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import logging
-from typing import Union
 
 import hydrogram
 from hydrogram import raw
@@ -27,7 +28,7 @@ log = logging.getLogger(__name__)
 
 
 class GetChatHistoryCount:
-    async def get_chat_history_count(self: "hydrogram.Client", chat_id: Union[int, str]) -> int:
+    async def get_chat_history_count(self: hydrogram.Client, chat_id: int | str) -> int:
         """Get the total count of messages in a chat.
 
         .. note::

--- a/hydrogram/methods/messages/get_discussion_message.py
+++ b/hydrogram/methods/messages/get_discussion_message.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw, types
@@ -25,10 +25,10 @@ from hydrogram import raw, types
 
 class GetDiscussionMessage:
     async def get_discussion_message(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
+        self: hydrogram.Client,
+        chat_id: int | str,
         message_id: int,
-    ) -> "types.Message":
+    ) -> types.Message:
         """Get the first discussion message of a channel post or a discussion thread in a group.
 
         Reply to the returned message to leave a comment on the linked channel post or to continue

--- a/hydrogram/methods/messages/get_discussion_replies.py
+++ b/hydrogram/methods/messages/get_discussion_replies.py
@@ -17,20 +17,24 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from collections.abc import AsyncGenerator
-from typing import Optional, Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import hydrogram
 from hydrogram import raw, types
 
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
 
 class GetDiscussionReplies:
     async def get_discussion_replies(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
+        self: hydrogram.Client,
+        chat_id: int | str,
         message_id: int,
         limit: int = 0,
-    ) -> Optional[AsyncGenerator["types.Message", None]]:
+    ) -> AsyncGenerator[types.Message, None] | None:
         """Get the message replies of a discussion thread.
 
         .. include:: /_includes/usable-by/users.rst

--- a/hydrogram/methods/messages/get_discussion_replies_count.py
+++ b/hydrogram/methods/messages/get_discussion_replies_count.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
@@ -25,8 +25,8 @@ from hydrogram import raw
 
 class GetDiscussionRepliesCount:
     async def get_discussion_replies_count(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
+        self: hydrogram.Client,
+        chat_id: int | str,
         message_id: int,
     ) -> int:
         """Get the total count of replies in a discussion thread.

--- a/hydrogram/methods/messages/get_media_group.py
+++ b/hydrogram/methods/messages/get_media_group.py
@@ -17,8 +17,9 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import logging
-from typing import Union
 
 import hydrogram
 from hydrogram import types
@@ -28,8 +29,8 @@ log = logging.getLogger(__name__)
 
 class GetMediaGroup:
     async def get_media_group(
-        self: "hydrogram.Client", chat_id: Union[int, str], message_id: int
-    ) -> list["types.Message"]:
+        self: hydrogram.Client, chat_id: int | str, message_id: int
+    ) -> list[types.Message]:
         """Get the media group a message belongs to.
 
         .. include:: /_includes/usable-by/users-bots.rst

--- a/hydrogram/methods/messages/get_messages.py
+++ b/hydrogram/methods/messages/get_messages.py
@@ -17,12 +17,16 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import logging
-from collections.abc import Iterable
-from typing import Optional, Union
+from typing import TYPE_CHECKING
 
 import hydrogram
 from hydrogram import raw, types, utils
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 log = logging.getLogger(__name__)
 
@@ -32,12 +36,12 @@ log = logging.getLogger(__name__)
 
 class GetMessages:
     async def get_messages(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
-        message_ids: Optional[Union[int, Iterable[int]]] = None,
-        reply_to_message_ids: Optional[Union[int, Iterable[int]]] = None,
+        self: hydrogram.Client,
+        chat_id: int | str,
+        message_ids: int | Iterable[int] | None = None,
+        reply_to_message_ids: int | Iterable[int] | None = None,
         replies: int = 1,
-    ) -> Union["types.Message", list["types.Message"]]:
+    ) -> types.Message | list[types.Message]:
         """Get one or more messages from a chat by using message identifiers.
 
         You can retrieve up to 200 messages at once.

--- a/hydrogram/methods/messages/read_chat_history.py
+++ b/hydrogram/methods/messages/read_chat_history.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
@@ -25,7 +25,7 @@ from hydrogram import raw
 
 class ReadChatHistory:
     async def read_chat_history(
-        self: "hydrogram.Client", chat_id: Union[int, str], max_id: int = 0
+        self: hydrogram.Client, chat_id: int | str, max_id: int = 0
     ) -> bool:
         """Mark a chat's message history as read.
 

--- a/hydrogram/methods/messages/retract_vote.py
+++ b/hydrogram/methods/messages/retract_vote.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw, types
@@ -25,8 +25,8 @@ from hydrogram import raw, types
 
 class RetractVote:
     async def retract_vote(
-        self: "hydrogram.Client", chat_id: Union[int, str], message_id: int
-    ) -> "types.Poll":
+        self: hydrogram.Client, chat_id: int | str, message_id: int
+    ) -> types.Poll:
         """Retract your vote in a poll.
 
         .. include:: /_includes/usable-by/users.rst

--- a/hydrogram/methods/messages/search_global.py
+++ b/hydrogram/methods/messages/search_global.py
@@ -17,20 +17,24 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from collections.abc import AsyncGenerator
-from typing import Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import hydrogram
 from hydrogram import enums, raw, types, utils
 
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
 
 class SearchGlobal:
     async def search_global(
-        self: "hydrogram.Client",
+        self: hydrogram.Client,
         query: str = "",
-        filter: "enums.MessagesFilter" = enums.MessagesFilter.EMPTY,
+        filter: enums.MessagesFilter = enums.MessagesFilter.EMPTY,
         limit: int = 0,
-    ) -> Optional[AsyncGenerator["types.Message", None]]:
+    ) -> AsyncGenerator[types.Message, None] | None:
         """Search messages globally from all of your chats.
 
         If you want to get the messages count only, see :meth:`~hydrogram.Client.search_global_count`.

--- a/hydrogram/methods/messages/search_messages.py
+++ b/hydrogram/methods/messages/search_messages.py
@@ -17,22 +17,26 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from collections.abc import AsyncGenerator
-from typing import Optional, Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import hydrogram
 from hydrogram import enums, raw, types, utils
 
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
 
 async def get_chunk(
     client,
-    chat_id: Union[int, str],
+    chat_id: int | str,
     query: str = "",
-    filter: "enums.MessagesFilter" = enums.MessagesFilter.EMPTY,
+    filter: enums.MessagesFilter = enums.MessagesFilter.EMPTY,
     offset: int = 0,
     limit: int = 100,
-    from_user: Optional[Union[int, str]] = None,
-) -> list["types.Message"]:
+    from_user: int | str | None = None,
+) -> list[types.Message]:
     r = await client.invoke(
         raw.functions.messages.Search(
             peer=await client.resolve_peer(chat_id),
@@ -56,14 +60,14 @@ async def get_chunk(
 
 class SearchMessages:
     async def search_messages(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
+        self: hydrogram.Client,
+        chat_id: int | str,
         query: str = "",
         offset: int = 0,
-        filter: "enums.MessagesFilter" = enums.MessagesFilter.EMPTY,
+        filter: enums.MessagesFilter = enums.MessagesFilter.EMPTY,
         limit: int = 0,
-        from_user: Optional[Union[int, str]] = None,
-    ) -> Optional[AsyncGenerator["types.Message", None]]:
+        from_user: int | str | None = None,
+    ) -> AsyncGenerator[types.Message, None] | None:
         """Search for text and media messages inside a specific chat.
 
         If you want to get the messages count only, see :meth:`~hydrogram.Client.search_messages_count`.

--- a/hydrogram/methods/messages/search_messages_count.py
+++ b/hydrogram/methods/messages/search_messages_count.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional, Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import enums, raw
@@ -25,11 +25,11 @@ from hydrogram import enums, raw
 
 class SearchMessagesCount:
     async def search_messages_count(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
+        self: hydrogram.Client,
+        chat_id: int | str,
         query: str = "",
-        filter: "enums.MessagesFilter" = enums.MessagesFilter.EMPTY,
-        from_user: Optional[Union[int, str]] = None,
+        filter: enums.MessagesFilter = enums.MessagesFilter.EMPTY,
+        from_user: int | str | None = None,
     ) -> int:
         """Get the count of messages resulting from a search inside a chat.
 

--- a/hydrogram/methods/messages/send_animation.py
+++ b/hydrogram/methods/messages/send_animation.py
@@ -17,47 +17,49 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import re
-from datetime import datetime
 from pathlib import Path
-from typing import BinaryIO, Callable, Optional, Union
+from typing import TYPE_CHECKING, BinaryIO, Callable
 
 import hydrogram
 from hydrogram import StopTransmission, enums, raw, types, utils
 from hydrogram.errors import FilePartMissing
 from hydrogram.file_id import FileType
 
+if TYPE_CHECKING:
+    from datetime import datetime
+
 
 class SendAnimation:
     async def send_animation(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
-        animation: Union[str, BinaryIO],
+        self: hydrogram.Client,
+        chat_id: int | str,
+        animation: str | BinaryIO,
         caption: str = "",
         *,
-        message_thread_id: Optional[int] = None,
+        message_thread_id: int | None = None,
         unsave: bool = False,
-        parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: Optional[list["types.MessageEntity"]] = None,
-        has_spoiler: Optional[bool] = None,
+        parse_mode: enums.ParseMode | None = None,
+        caption_entities: list[types.MessageEntity] | None = None,
+        has_spoiler: bool | None = None,
         duration: int = 0,
         width: int = 0,
         height: int = 0,
-        thumb: Optional[Union[str, BinaryIO]] = None,
-        file_name: Optional[str] = None,
-        disable_notification: Optional[bool] = None,
-        reply_to_message_id: Optional[int] = None,
-        schedule_date: Optional[datetime] = None,
-        protect_content: Optional[bool] = None,
-        reply_markup: Union[
-            "types.InlineKeyboardMarkup",
-            "types.ReplyKeyboardMarkup",
-            "types.ReplyKeyboardRemove",
-            "types.ForceReply",
-        ] = None,
-        progress: Optional[Callable] = None,
+        thumb: str | BinaryIO | None = None,
+        file_name: str | None = None,
+        disable_notification: bool | None = None,
+        reply_to_message_id: int | None = None,
+        schedule_date: datetime | None = None,
+        protect_content: bool | None = None,
+        reply_markup: types.InlineKeyboardMarkup
+        | types.ReplyKeyboardMarkup
+        | types.ReplyKeyboardRemove
+        | types.ForceReply = None,
+        progress: Callable | None = None,
         progress_args: tuple = (),
-    ) -> Optional["types.Message"]:
+    ) -> types.Message | None:
         """Send animation files (animation or H.264/MPEG-4 AVC video without sound).
 
         .. include:: /_includes/usable-by/users-bots.rst

--- a/hydrogram/methods/messages/send_audio.py
+++ b/hydrogram/methods/messages/send_audio.py
@@ -17,45 +17,47 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import re
-from datetime import datetime
 from pathlib import Path
-from typing import BinaryIO, Callable, Optional, Union
+from typing import TYPE_CHECKING, BinaryIO, Callable
 
 import hydrogram
 from hydrogram import StopTransmission, enums, raw, types, utils
 from hydrogram.errors import FilePartMissing
 from hydrogram.file_id import FileType
 
+if TYPE_CHECKING:
+    from datetime import datetime
+
 
 class SendAudio:
     async def send_audio(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
-        audio: Union[str, BinaryIO],
+        self: hydrogram.Client,
+        chat_id: int | str,
+        audio: str | BinaryIO,
         caption: str = "",
         *,
-        message_thread_id: Optional[int] = None,
-        parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: Optional[list["types.MessageEntity"]] = None,
+        message_thread_id: int | None = None,
+        parse_mode: enums.ParseMode | None = None,
+        caption_entities: list[types.MessageEntity] | None = None,
         duration: int = 0,
-        performer: Optional[str] = None,
-        title: Optional[str] = None,
-        thumb: Optional[Union[str, BinaryIO]] = None,
-        file_name: Optional[str] = None,
-        disable_notification: Optional[bool] = None,
-        reply_to_message_id: Optional[int] = None,
-        schedule_date: Optional[datetime] = None,
-        protect_content: Optional[bool] = None,
-        reply_markup: Union[
-            "types.InlineKeyboardMarkup",
-            "types.ReplyKeyboardMarkup",
-            "types.ReplyKeyboardRemove",
-            "types.ForceReply",
-        ] = None,
-        progress: Optional[Callable] = None,
+        performer: str | None = None,
+        title: str | None = None,
+        thumb: str | BinaryIO | None = None,
+        file_name: str | None = None,
+        disable_notification: bool | None = None,
+        reply_to_message_id: int | None = None,
+        schedule_date: datetime | None = None,
+        protect_content: bool | None = None,
+        reply_markup: types.InlineKeyboardMarkup
+        | types.ReplyKeyboardMarkup
+        | types.ReplyKeyboardRemove
+        | types.ForceReply = None,
+        progress: Callable | None = None,
         progress_args: tuple = (),
-    ) -> Optional["types.Message"]:
+    ) -> types.Message | None:
         """Send audio files.
 
         For sending voice messages, use the :meth:`~hydrogram.Client.send_voice` method instead.

--- a/hydrogram/methods/messages/send_cached_media.py
+++ b/hydrogram/methods/messages/send_cached_media.py
@@ -17,34 +17,36 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from datetime import datetime
-from typing import Optional, Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import hydrogram
 from hydrogram import enums, raw, types, utils
 
+if TYPE_CHECKING:
+    from datetime import datetime
+
 
 class SendCachedMedia:
     async def send_cached_media(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
+        self: hydrogram.Client,
+        chat_id: int | str,
         file_id: str,
         caption: str = "",
         *,
-        message_thread_id: Optional[int] = None,
-        parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: Optional[list["types.MessageEntity"]] = None,
-        disable_notification: Optional[bool] = None,
-        reply_to_message_id: Optional[int] = None,
-        schedule_date: Optional[datetime] = None,
-        protect_content: Optional[bool] = None,
-        reply_markup: Union[
-            "types.InlineKeyboardMarkup",
-            "types.ReplyKeyboardMarkup",
-            "types.ReplyKeyboardRemove",
-            "types.ForceReply",
-        ] = None,
-    ) -> Optional["types.Message"]:
+        message_thread_id: int | None = None,
+        parse_mode: enums.ParseMode | None = None,
+        caption_entities: list[types.MessageEntity] | None = None,
+        disable_notification: bool | None = None,
+        reply_to_message_id: int | None = None,
+        schedule_date: datetime | None = None,
+        protect_content: bool | None = None,
+        reply_markup: types.InlineKeyboardMarkup
+        | types.ReplyKeyboardMarkup
+        | types.ReplyKeyboardRemove
+        | types.ForceReply = None,
+    ) -> types.Message | None:
         """Send any media stored on the Telegram servers using a file_id.
 
         This convenience method works with any valid file_id only.

--- a/hydrogram/methods/messages/send_chat_action.py
+++ b/hydrogram/methods/messages/send_chat_action.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional, Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import enums, raw
@@ -25,11 +25,11 @@ from hydrogram import enums, raw
 
 class SendChatAction:
     async def send_chat_action(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
-        action: "enums.ChatAction",
+        self: hydrogram.Client,
+        chat_id: int | str,
+        action: enums.ChatAction,
         *,
-        message_thread_id: Optional[int] = None,
+        message_thread_id: int | None = None,
     ) -> bool:
         """Tell the other party that something is happening on your side.
 

--- a/hydrogram/methods/messages/send_contact.py
+++ b/hydrogram/methods/messages/send_contact.py
@@ -17,34 +17,36 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from datetime import datetime
-from typing import Optional, Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import hydrogram
 from hydrogram import raw, types, utils
 
+if TYPE_CHECKING:
+    from datetime import datetime
+
 
 class SendContact:
     async def send_contact(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
+        self: hydrogram.Client,
+        chat_id: int | str,
         phone_number: str,
         first_name: str,
-        last_name: Optional[str] = None,
+        last_name: str | None = None,
         *,
-        message_thread_id: Optional[int] = None,
-        vcard: Optional[str] = None,
-        disable_notification: Optional[bool] = None,
-        reply_to_message_id: Optional[int] = None,
-        schedule_date: Optional[datetime] = None,
-        protect_content: Optional[bool] = None,
-        reply_markup: Union[
-            "types.InlineKeyboardMarkup",
-            "types.ReplyKeyboardMarkup",
-            "types.ReplyKeyboardRemove",
-            "types.ForceReply",
-        ] = None,
-    ) -> "types.Message":
+        message_thread_id: int | None = None,
+        vcard: str | None = None,
+        disable_notification: bool | None = None,
+        reply_to_message_id: int | None = None,
+        schedule_date: datetime | None = None,
+        protect_content: bool | None = None,
+        reply_markup: types.InlineKeyboardMarkup
+        | types.ReplyKeyboardMarkup
+        | types.ReplyKeyboardRemove
+        | types.ForceReply = None,
+    ) -> types.Message:
         """Send phone contacts.
 
         .. include:: /_includes/usable-by/users-bots.rst

--- a/hydrogram/methods/messages/send_dice.py
+++ b/hydrogram/methods/messages/send_dice.py
@@ -17,31 +17,33 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from datetime import datetime
-from typing import Optional, Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import hydrogram
 from hydrogram import raw, types, utils
 
+if TYPE_CHECKING:
+    from datetime import datetime
+
 
 class SendDice:
     async def send_dice(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
+        self: hydrogram.Client,
+        chat_id: int | str,
         emoji: str = "🎲",
         *,
-        message_thread_id: Optional[int] = None,
-        disable_notification: Optional[bool] = None,
-        reply_to_message_id: Optional[int] = None,
-        schedule_date: Optional[datetime] = None,
-        protect_content: Optional[bool] = None,
-        reply_markup: Union[
-            "types.InlineKeyboardMarkup",
-            "types.ReplyKeyboardMarkup",
-            "types.ReplyKeyboardRemove",
-            "types.ForceReply",
-        ] = None,
-    ) -> Optional["types.Message"]:
+        message_thread_id: int | None = None,
+        disable_notification: bool | None = None,
+        reply_to_message_id: int | None = None,
+        schedule_date: datetime | None = None,
+        protect_content: bool | None = None,
+        reply_markup: types.InlineKeyboardMarkup
+        | types.ReplyKeyboardMarkup
+        | types.ReplyKeyboardRemove
+        | types.ForceReply = None,
+    ) -> types.Message | None:
         """Send a dice with a random value from 1 to 6.
 
         .. include:: /_includes/usable-by/users-bots.rst

--- a/hydrogram/methods/messages/send_document.py
+++ b/hydrogram/methods/messages/send_document.py
@@ -17,43 +17,45 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import re
-from datetime import datetime
 from pathlib import Path
-from typing import BinaryIO, Callable, Optional, Union
+from typing import TYPE_CHECKING, BinaryIO, Callable
 
 import hydrogram
 from hydrogram import StopTransmission, enums, raw, types, utils
 from hydrogram.errors import FilePartMissing
 from hydrogram.file_id import FileType
 
+if TYPE_CHECKING:
+    from datetime import datetime
+
 
 class SendDocument:
     async def send_document(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
-        document: Union[str, BinaryIO],
-        thumb: Optional[Union[str, BinaryIO]] = None,
+        self: hydrogram.Client,
+        chat_id: int | str,
+        document: str | BinaryIO,
+        thumb: str | BinaryIO | None = None,
         caption: str = "",
         *,
-        message_thread_id: Optional[int] = None,
-        parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: Optional[list["types.MessageEntity"]] = None,
-        file_name: Optional[str] = None,
-        force_document: Optional[bool] = None,
-        disable_notification: Optional[bool] = None,
-        reply_to_message_id: Optional[int] = None,
-        schedule_date: Optional[datetime] = None,
-        protect_content: Optional[bool] = None,
-        reply_markup: Union[
-            "types.InlineKeyboardMarkup",
-            "types.ReplyKeyboardMarkup",
-            "types.ReplyKeyboardRemove",
-            "types.ForceReply",
-        ] = None,
-        progress: Optional[Callable] = None,
+        message_thread_id: int | None = None,
+        parse_mode: enums.ParseMode | None = None,
+        caption_entities: list[types.MessageEntity] | None = None,
+        file_name: str | None = None,
+        force_document: bool | None = None,
+        disable_notification: bool | None = None,
+        reply_to_message_id: int | None = None,
+        schedule_date: datetime | None = None,
+        protect_content: bool | None = None,
+        reply_markup: types.InlineKeyboardMarkup
+        | types.ReplyKeyboardMarkup
+        | types.ReplyKeyboardRemove
+        | types.ForceReply = None,
+        progress: Callable | None = None,
         progress_args: tuple = (),
-    ) -> Optional["types.Message"]:
+    ) -> types.Message | None:
         """Send generic files.
 
         .. include:: /_includes/usable-by/users-bots.rst

--- a/hydrogram/methods/messages/send_location.py
+++ b/hydrogram/methods/messages/send_location.py
@@ -17,32 +17,34 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from datetime import datetime
-from typing import Optional, Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import hydrogram
 from hydrogram import raw, types, utils
 
+if TYPE_CHECKING:
+    from datetime import datetime
+
 
 class SendLocation:
     async def send_location(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
+        self: hydrogram.Client,
+        chat_id: int | str,
         latitude: float,
         longitude: float,
         *,
-        message_thread_id: Optional[int] = None,
-        disable_notification: Optional[bool] = None,
-        reply_to_message_id: Optional[int] = None,
-        schedule_date: Optional[datetime] = None,
-        protect_content: Optional[bool] = None,
-        reply_markup: Union[
-            "types.InlineKeyboardMarkup",
-            "types.ReplyKeyboardMarkup",
-            "types.ReplyKeyboardRemove",
-            "types.ForceReply",
-        ] = None,
-    ) -> "types.Message":
+        message_thread_id: int | None = None,
+        disable_notification: bool | None = None,
+        reply_to_message_id: int | None = None,
+        schedule_date: datetime | None = None,
+        protect_content: bool | None = None,
+        reply_markup: types.InlineKeyboardMarkup
+        | types.ReplyKeyboardMarkup
+        | types.ReplyKeyboardRemove
+        | types.ForceReply = None,
+    ) -> types.Message:
         """Send points on the map.
 
         .. include:: /_includes/usable-by/users-bots.rst

--- a/hydrogram/methods/messages/send_media_group.py
+++ b/hydrogram/methods/messages/send_media_group.py
@@ -17,15 +17,19 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import logging
 import re
-from datetime import datetime
 from pathlib import Path
-from typing import Optional, Union
+from typing import TYPE_CHECKING
 
 import hydrogram
 from hydrogram import raw, types, utils
 from hydrogram.file_id import FileType
+
+if TYPE_CHECKING:
+    from datetime import datetime
 
 log = logging.getLogger(__name__)
 
@@ -33,23 +37,21 @@ log = logging.getLogger(__name__)
 class SendMediaGroup:
     # TODO: Add progress parameter
     async def send_media_group(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
+        self: hydrogram.Client,
+        chat_id: int | str,
         media: list[
-            Union[
-                "types.InputMediaPhoto",
-                "types.InputMediaVideo",
-                "types.InputMediaAudio",
-                "types.InputMediaDocument",
-            ]
+            types.InputMediaPhoto
+            | types.InputMediaVideo
+            | types.InputMediaAudio
+            | types.InputMediaDocument
         ],
         *,
-        message_thread_id: Optional[int] = None,
-        disable_notification: Optional[bool] = None,
-        reply_to_message_id: Optional[int] = None,
-        schedule_date: Optional[datetime] = None,
-        protect_content: Optional[bool] = None,
-    ) -> list["types.Message"]:
+        message_thread_id: int | None = None,
+        disable_notification: bool | None = None,
+        reply_to_message_id: int | None = None,
+        schedule_date: datetime | None = None,
+        protect_content: bool | None = None,
+    ) -> list[types.Message]:
         """Send a group of photos or videos as an album.
 
         .. include:: /_includes/usable-by/users-bots.rst

--- a/hydrogram/methods/messages/send_message.py
+++ b/hydrogram/methods/messages/send_message.py
@@ -17,34 +17,36 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from datetime import datetime
-from typing import Optional, Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import hydrogram
 from hydrogram import enums, raw, types, utils
 
+if TYPE_CHECKING:
+    from datetime import datetime
+
 
 class SendMessage:
     async def send_message(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
+        self: hydrogram.Client,
+        chat_id: int | str,
         text: str,
         *,
-        message_thread_id: Optional[int] = None,
-        parse_mode: Optional["enums.ParseMode"] = None,
-        entities: Optional[list["types.MessageEntity"]] = None,
-        disable_web_page_preview: Optional[bool] = None,
-        disable_notification: Optional[bool] = None,
-        reply_to_message_id: Optional[int] = None,
-        schedule_date: Optional[datetime] = None,
-        protect_content: Optional[bool] = None,
-        reply_markup: Union[
-            "types.InlineKeyboardMarkup",
-            "types.ReplyKeyboardMarkup",
-            "types.ReplyKeyboardRemove",
-            "types.ForceReply",
-        ] = None,
-    ) -> "types.Message":
+        message_thread_id: int | None = None,
+        parse_mode: enums.ParseMode | None = None,
+        entities: list[types.MessageEntity] | None = None,
+        disable_web_page_preview: bool | None = None,
+        disable_notification: bool | None = None,
+        reply_to_message_id: int | None = None,
+        schedule_date: datetime | None = None,
+        protect_content: bool | None = None,
+        reply_markup: types.InlineKeyboardMarkup
+        | types.ReplyKeyboardMarkup
+        | types.ReplyKeyboardRemove
+        | types.ForceReply = None,
+    ) -> types.Message:
         """Send text messages.
 
         .. include:: /_includes/usable-by/users-bots.rst

--- a/hydrogram/methods/messages/send_photo.py
+++ b/hydrogram/methods/messages/send_photo.py
@@ -17,42 +17,44 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import re
-from datetime import datetime
 from pathlib import Path
-from typing import BinaryIO, Callable, Optional, Union
+from typing import TYPE_CHECKING, BinaryIO, Callable
 
 import hydrogram
 from hydrogram import enums, raw, types, utils
 from hydrogram.errors import FilePartMissing
 from hydrogram.file_id import FileType
 
+if TYPE_CHECKING:
+    from datetime import datetime
+
 
 class SendPhoto:
     async def send_photo(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
-        photo: Union[str, BinaryIO],
+        self: hydrogram.Client,
+        chat_id: int | str,
+        photo: str | BinaryIO,
         caption: str = "",
         *,
-        message_thread_id: Optional[int] = None,
-        parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: Optional[list["types.MessageEntity"]] = None,
-        has_spoiler: Optional[bool] = None,
-        ttl_seconds: Optional[int] = None,
-        disable_notification: Optional[bool] = None,
-        reply_to_message_id: Optional[int] = None,
-        schedule_date: Optional[datetime] = None,
-        protect_content: Optional[bool] = None,
-        reply_markup: Union[
-            "types.InlineKeyboardMarkup",
-            "types.ReplyKeyboardMarkup",
-            "types.ReplyKeyboardRemove",
-            "types.ForceReply",
-        ] = None,
-        progress: Optional[Callable] = None,
+        message_thread_id: int | None = None,
+        parse_mode: enums.ParseMode | None = None,
+        caption_entities: list[types.MessageEntity] | None = None,
+        has_spoiler: bool | None = None,
+        ttl_seconds: int | None = None,
+        disable_notification: bool | None = None,
+        reply_to_message_id: int | None = None,
+        schedule_date: datetime | None = None,
+        protect_content: bool | None = None,
+        reply_markup: types.InlineKeyboardMarkup
+        | types.ReplyKeyboardMarkup
+        | types.ReplyKeyboardRemove
+        | types.ForceReply = None,
+        progress: Callable | None = None,
         progress_args: tuple = (),
-    ) -> Optional["types.Message"]:
+    ) -> types.Message | None:
         """Send photos.
 
         .. include:: /_includes/usable-by/users-bots.rst

--- a/hydrogram/methods/messages/send_poll.py
+++ b/hydrogram/methods/messages/send_poll.py
@@ -17,42 +17,44 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from datetime import datetime
-from typing import Optional, Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import hydrogram
 from hydrogram import enums, raw, types, utils
 
+if TYPE_CHECKING:
+    from datetime import datetime
+
 
 class SendPoll:
     async def send_poll(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
+        self: hydrogram.Client,
+        chat_id: int | str,
         question: str,
         options: list[str],
         *,
-        message_thread_id: Optional[int] = None,
+        message_thread_id: int | None = None,
         is_anonymous: bool = True,
-        type: "enums.PollType" = enums.PollType.REGULAR,
-        allows_multiple_answers: Optional[bool] = None,
-        correct_option_id: Optional[int] = None,
-        explanation: Optional[str] = None,
-        explanation_parse_mode: "enums.ParseMode" = None,
-        explanation_entities: Optional[list["types.MessageEntity"]] = None,
-        open_period: Optional[int] = None,
-        close_date: Optional[datetime] = None,
-        is_closed: Optional[bool] = None,
-        disable_notification: Optional[bool] = None,
-        protect_content: Optional[bool] = None,
-        reply_to_message_id: Optional[int] = None,
-        schedule_date: Optional[datetime] = None,
-        reply_markup: Union[
-            "types.InlineKeyboardMarkup",
-            "types.ReplyKeyboardMarkup",
-            "types.ReplyKeyboardRemove",
-            "types.ForceReply",
-        ] = None,
-    ) -> "types.Message":
+        type: enums.PollType = enums.PollType.REGULAR,
+        allows_multiple_answers: bool | None = None,
+        correct_option_id: int | None = None,
+        explanation: str | None = None,
+        explanation_parse_mode: enums.ParseMode = None,
+        explanation_entities: list[types.MessageEntity] | None = None,
+        open_period: int | None = None,
+        close_date: datetime | None = None,
+        is_closed: bool | None = None,
+        disable_notification: bool | None = None,
+        protect_content: bool | None = None,
+        reply_to_message_id: int | None = None,
+        schedule_date: datetime | None = None,
+        reply_markup: types.InlineKeyboardMarkup
+        | types.ReplyKeyboardMarkup
+        | types.ReplyKeyboardRemove
+        | types.ForceReply = None,
+    ) -> types.Message:
         """Send a new poll.
 
         .. include:: /_includes/usable-by/users-bots.rst

--- a/hydrogram/methods/messages/send_reaction.py
+++ b/hydrogram/methods/messages/send_reaction.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
@@ -25,8 +25,8 @@ from hydrogram import raw
 
 class SendReaction:
     async def send_reaction(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
+        self: hydrogram.Client,
+        chat_id: int | str,
         message_id: int,
         emoji: str = "",
         big: bool = False,

--- a/hydrogram/methods/messages/send_sticker.py
+++ b/hydrogram/methods/messages/send_sticker.py
@@ -17,37 +17,39 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import re
-from datetime import datetime
 from pathlib import Path
-from typing import BinaryIO, Callable, Optional, Union
+from typing import TYPE_CHECKING, BinaryIO, Callable
 
 import hydrogram
 from hydrogram import StopTransmission, raw, types, utils
 from hydrogram.errors import FilePartMissing
 from hydrogram.file_id import FileType
 
+if TYPE_CHECKING:
+    from datetime import datetime
+
 
 class SendSticker:
     async def send_sticker(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
-        sticker: Union[str, BinaryIO],
+        self: hydrogram.Client,
+        chat_id: int | str,
+        sticker: str | BinaryIO,
         *,
-        message_thread_id: Optional[int] = None,
-        disable_notification: Optional[bool] = None,
-        reply_to_message_id: Optional[int] = None,
-        schedule_date: Optional[datetime] = None,
-        protect_content: Optional[bool] = None,
-        reply_markup: Union[
-            "types.InlineKeyboardMarkup",
-            "types.ReplyKeyboardMarkup",
-            "types.ReplyKeyboardRemove",
-            "types.ForceReply",
-        ] = None,
-        progress: Optional[Callable] = None,
+        message_thread_id: int | None = None,
+        disable_notification: bool | None = None,
+        reply_to_message_id: int | None = None,
+        schedule_date: datetime | None = None,
+        protect_content: bool | None = None,
+        reply_markup: types.InlineKeyboardMarkup
+        | types.ReplyKeyboardMarkup
+        | types.ReplyKeyboardRemove
+        | types.ForceReply = None,
+        progress: Callable | None = None,
         progress_args: tuple = (),
-    ) -> Optional["types.Message"]:
+    ) -> types.Message | None:
         """Send static .webp or animated .tgs stickers.
 
         .. include:: /_includes/usable-by/users-bots.rst

--- a/hydrogram/methods/messages/send_venue.py
+++ b/hydrogram/methods/messages/send_venue.py
@@ -17,36 +17,38 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from datetime import datetime
-from typing import Optional, Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import hydrogram
 from hydrogram import raw, types, utils
 
+if TYPE_CHECKING:
+    from datetime import datetime
+
 
 class SendVenue:
     async def send_venue(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
+        self: hydrogram.Client,
+        chat_id: int | str,
         latitude: float,
         longitude: float,
         title: str,
         address: str,
         *,
-        message_thread_id: Optional[int] = None,
+        message_thread_id: int | None = None,
         foursquare_id: str = "",
         foursquare_type: str = "",
-        disable_notification: Optional[bool] = None,
-        reply_to_message_id: Optional[int] = None,
-        schedule_date: Optional[datetime] = None,
-        protect_content: Optional[bool] = None,
-        reply_markup: Union[
-            "types.InlineKeyboardMarkup",
-            "types.ReplyKeyboardMarkup",
-            "types.ReplyKeyboardRemove",
-            "types.ForceReply",
-        ] = None,
-    ) -> "types.Message":
+        disable_notification: bool | None = None,
+        reply_to_message_id: int | None = None,
+        schedule_date: datetime | None = None,
+        protect_content: bool | None = None,
+        reply_markup: types.InlineKeyboardMarkup
+        | types.ReplyKeyboardMarkup
+        | types.ReplyKeyboardRemove
+        | types.ForceReply = None,
+    ) -> types.Message:
         """Send information about a venue.
 
         .. include:: /_includes/usable-by/users-bots.rst

--- a/hydrogram/methods/messages/send_video.py
+++ b/hydrogram/methods/messages/send_video.py
@@ -17,48 +17,50 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import re
-from datetime import datetime
 from pathlib import Path
-from typing import BinaryIO, Callable, Optional, Union
+from typing import TYPE_CHECKING, BinaryIO, Callable
 
 import hydrogram
 from hydrogram import StopTransmission, enums, raw, types, utils
 from hydrogram.errors import FilePartMissing
 from hydrogram.file_id import FileType
 
+if TYPE_CHECKING:
+    from datetime import datetime
+
 
 class SendVideo:
     async def send_video(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
-        video: Union[str, BinaryIO],
+        self: hydrogram.Client,
+        chat_id: int | str,
+        video: str | BinaryIO,
         caption: str = "",
         *,
-        message_thread_id: Optional[int] = None,
-        parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: Optional[list["types.MessageEntity"]] = None,
-        has_spoiler: Optional[bool] = None,
-        ttl_seconds: Optional[int] = None,
+        message_thread_id: int | None = None,
+        parse_mode: enums.ParseMode | None = None,
+        caption_entities: list[types.MessageEntity] | None = None,
+        has_spoiler: bool | None = None,
+        ttl_seconds: int | None = None,
         duration: int = 0,
         width: int = 0,
         height: int = 0,
-        thumb: Optional[Union[str, BinaryIO]] = None,
-        file_name: Optional[str] = None,
+        thumb: str | BinaryIO | None = None,
+        file_name: str | None = None,
         supports_streaming: bool = True,
-        disable_notification: Optional[bool] = None,
-        reply_to_message_id: Optional[int] = None,
-        schedule_date: Optional[datetime] = None,
-        protect_content: Optional[bool] = None,
-        reply_markup: Union[
-            "types.InlineKeyboardMarkup",
-            "types.ReplyKeyboardMarkup",
-            "types.ReplyKeyboardRemove",
-            "types.ForceReply",
-        ] = None,
-        progress: Optional[Callable] = None,
+        disable_notification: bool | None = None,
+        reply_to_message_id: int | None = None,
+        schedule_date: datetime | None = None,
+        protect_content: bool | None = None,
+        reply_markup: types.InlineKeyboardMarkup
+        | types.ReplyKeyboardMarkup
+        | types.ReplyKeyboardRemove
+        | types.ForceReply = None,
+        progress: Callable | None = None,
         progress_args: tuple = (),
-    ) -> Optional["types.Message"]:
+    ) -> types.Message | None:
         """Send video files.
 
         .. include:: /_includes/usable-by/users-bots.rst

--- a/hydrogram/methods/messages/send_video_note.py
+++ b/hydrogram/methods/messages/send_video_note.py
@@ -17,39 +17,41 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from datetime import datetime
+from __future__ import annotations
+
 from pathlib import Path
-from typing import BinaryIO, Callable, Optional, Union
+from typing import TYPE_CHECKING, BinaryIO, Callable
 
 import hydrogram
 from hydrogram import StopTransmission, raw, types, utils
 from hydrogram.errors import FilePartMissing
 from hydrogram.file_id import FileType
 
+if TYPE_CHECKING:
+    from datetime import datetime
+
 
 class SendVideoNote:
     async def send_video_note(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
-        video_note: Union[str, BinaryIO],
+        self: hydrogram.Client,
+        chat_id: int | str,
+        video_note: str | BinaryIO,
         *,
-        message_thread_id: Optional[int] = None,
+        message_thread_id: int | None = None,
         duration: int = 0,
         length: int = 1,
-        thumb: Optional[Union[str, BinaryIO]] = None,
-        disable_notification: Optional[bool] = None,
-        reply_to_message_id: Optional[int] = None,
-        schedule_date: Optional[datetime] = None,
-        protect_content: Optional[bool] = None,
-        reply_markup: Union[
-            "types.InlineKeyboardMarkup",
-            "types.ReplyKeyboardMarkup",
-            "types.ReplyKeyboardRemove",
-            "types.ForceReply",
-        ] = None,
-        progress: Optional[Callable] = None,
+        thumb: str | BinaryIO | None = None,
+        disable_notification: bool | None = None,
+        reply_to_message_id: int | None = None,
+        schedule_date: datetime | None = None,
+        protect_content: bool | None = None,
+        reply_markup: types.InlineKeyboardMarkup
+        | types.ReplyKeyboardMarkup
+        | types.ReplyKeyboardRemove
+        | types.ForceReply = None,
+        progress: Callable | None = None,
         progress_args: tuple = (),
-    ) -> Optional["types.Message"]:
+    ) -> types.Message | None:
         """Send video messages.
 
         .. include:: /_includes/usable-by/users-bots.rst

--- a/hydrogram/methods/messages/send_voice.py
+++ b/hydrogram/methods/messages/send_voice.py
@@ -17,41 +17,43 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import re
-from datetime import datetime
 from pathlib import Path
-from typing import BinaryIO, Callable, Optional, Union
+from typing import TYPE_CHECKING, BinaryIO, Callable
 
 import hydrogram
 from hydrogram import StopTransmission, enums, raw, types, utils
 from hydrogram.errors import FilePartMissing
 from hydrogram.file_id import FileType
 
+if TYPE_CHECKING:
+    from datetime import datetime
+
 
 class SendVoice:
     async def send_voice(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
-        voice: Union[str, BinaryIO],
+        self: hydrogram.Client,
+        chat_id: int | str,
+        voice: str | BinaryIO,
         caption: str = "",
         *,
-        message_thread_id: Optional[int] = None,
-        parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: Optional[list["types.MessageEntity"]] = None,
+        message_thread_id: int | None = None,
+        parse_mode: enums.ParseMode | None = None,
+        caption_entities: list[types.MessageEntity] | None = None,
         duration: int = 0,
-        disable_notification: Optional[bool] = None,
-        reply_to_message_id: Optional[int] = None,
-        schedule_date: Optional[datetime] = None,
-        protect_content: Optional[bool] = None,
-        reply_markup: Union[
-            "types.InlineKeyboardMarkup",
-            "types.ReplyKeyboardMarkup",
-            "types.ReplyKeyboardRemove",
-            "types.ForceReply",
-        ] = None,
-        progress: Optional[Callable] = None,
+        disable_notification: bool | None = None,
+        reply_to_message_id: int | None = None,
+        schedule_date: datetime | None = None,
+        protect_content: bool | None = None,
+        reply_markup: types.InlineKeyboardMarkup
+        | types.ReplyKeyboardMarkup
+        | types.ReplyKeyboardRemove
+        | types.ForceReply = None,
+        progress: Callable | None = None,
         progress_args: tuple = (),
-    ) -> Optional["types.Message"]:
+    ) -> types.Message | None:
         """Send audio files.
 
         .. include:: /_includes/usable-by/users-bots.rst

--- a/hydrogram/methods/messages/stop_poll.py
+++ b/hydrogram/methods/messages/stop_poll.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw, types
@@ -25,11 +25,11 @@ from hydrogram import raw, types
 
 class StopPoll:
     async def stop_poll(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
+        self: hydrogram.Client,
+        chat_id: int | str,
         message_id: int,
-        reply_markup: "types.InlineKeyboardMarkup" = None,
-    ) -> "types.Poll":
+        reply_markup: types.InlineKeyboardMarkup = None,
+    ) -> types.Poll:
         """Stop a poll which was sent by you.
 
         Stopped polls can't be reopened and nobody will be able to vote in it anymore.

--- a/hydrogram/methods/messages/stream_media.py
+++ b/hydrogram/methods/messages/stream_media.py
@@ -17,8 +17,10 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import math
-from typing import BinaryIO, Optional, Union
+from typing import BinaryIO
 
 import hydrogram
 from hydrogram import types
@@ -27,11 +29,11 @@ from hydrogram.file_id import FileId
 
 class StreamMedia:
     async def stream_media(
-        self: "hydrogram.Client",
-        message: Union["types.Message", str],
+        self: hydrogram.Client,
+        message: types.Message | str,
         limit: int = 0,
         offset: int = 0,
-    ) -> Optional[Union[str, BinaryIO]]:
+    ) -> str | BinaryIO | None:
         """Stream the media from a message chunk by chunk.
 
         You can use this method to partially download a file into memory or to selectively download chunks of file.

--- a/hydrogram/methods/messages/vote_poll.py
+++ b/hydrogram/methods/messages/vote_poll.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw, types
@@ -25,11 +25,11 @@ from hydrogram import raw, types
 
 class VotePoll:
     async def vote_poll(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
+        self: hydrogram.Client,
+        chat_id: int | str,
         message_id: id,
-        options: Union[int, list[int]],
-    ) -> "types.Poll":
+        options: int | list[int],
+    ) -> types.Poll:
         """Vote a poll.
 
         .. include:: /_includes/usable-by/users.rst

--- a/hydrogram/methods/password/enable_cloud_password.py
+++ b/hydrogram/methods/password/enable_cloud_password.py
@@ -17,8 +17,9 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import os
-from typing import Optional
 
 import hydrogram
 from hydrogram import raw
@@ -27,7 +28,7 @@ from hydrogram.utils import btoi, compute_password_hash, itob
 
 class EnableCloudPassword:
     async def enable_cloud_password(
-        self: "hydrogram.Client", password: str, hint: str = "", email: Optional[str] = None
+        self: hydrogram.Client, password: str, hint: str = "", email: str | None = None
     ) -> bool:
         """Enable the Two-Step Verification security feature (Cloud Password) on your account.
 

--- a/hydrogram/methods/pyromod/ask.py
+++ b/hydrogram/methods/pyromod/ask.py
@@ -17,25 +17,29 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional, Union
+from __future__ import annotations
 
-import hydrogram
-from hydrogram.filters import Filter
+from typing import TYPE_CHECKING
+
 from hydrogram.types import ListenerTypes
+
+if TYPE_CHECKING:
+    import hydrogram
+    from hydrogram.filters import Filter
 
 
 class Ask:
     async def ask(
-        self: "hydrogram.Client",
-        chat_id: Union[Union[int, str], list[Union[int, str]]],
+        self: hydrogram.Client,
+        chat_id: int | str | list[int | str],
         text: str,
-        filters: Optional[Filter] = None,
+        filters: Filter | None = None,
         listener_type: ListenerTypes = ListenerTypes.MESSAGE,
-        timeout: Optional[int] = None,
+        timeout: int | None = None,
         unallowed_click_alert: bool = True,
-        user_id: Optional[Union[int, str, list[Union[int, str]]]] = None,
-        message_id: Optional[Union[int, list[int]]] = None,
-        inline_message_id: Optional[Union[str, list[str]]] = None,
+        user_id: int | str | list[int | str] | None = None,
+        message_id: int | list[int] | None = None,
+        inline_message_id: str | list[str] | None = None,
         *args,
         **kwargs,
     ):

--- a/hydrogram/methods/pyromod/get_listener_matching_with_data.py
+++ b/hydrogram/methods/pyromod/get_listener_matching_with_data.py
@@ -17,16 +17,19 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
+from __future__ import annotations
 
-import hydrogram
-from hydrogram.types import Identifier, Listener, ListenerTypes
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import hydrogram
+    from hydrogram.types import Identifier, Listener, ListenerTypes
 
 
 class GetListenerMatchingWithData:
     def get_listener_matching_with_data(
-        self: "hydrogram.Client", data: Identifier, listener_type: ListenerTypes
-    ) -> Optional[Listener]:
+        self: hydrogram.Client, data: Identifier, listener_type: ListenerTypes
+    ) -> Listener | None:
         """
         Gets a listener that matches the given data.
 

--- a/hydrogram/methods/pyromod/get_listener_matching_with_identifier_pattern.py
+++ b/hydrogram/methods/pyromod/get_listener_matching_with_identifier_pattern.py
@@ -17,16 +17,19 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
+from __future__ import annotations
 
-import hydrogram
-from hydrogram.types import Identifier, Listener, ListenerTypes
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import hydrogram
+    from hydrogram.types import Identifier, Listener, ListenerTypes
 
 
 class GetListenerMatchingWithIdentifierPattern:
     def get_listener_matching_with_identifier_pattern(
-        self: "hydrogram.Client", pattern: Identifier, listener_type: ListenerTypes
-    ) -> Optional[Listener]:
+        self: hydrogram.Client, pattern: Identifier, listener_type: ListenerTypes
+    ) -> Listener | None:
         """
         Gets a listener that matches the given identifier pattern.
 

--- a/hydrogram/methods/pyromod/get_many_listeners_matching_with_data.py
+++ b/hydrogram/methods/pyromod/get_many_listeners_matching_with_data.py
@@ -18,8 +18,12 @@
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 
-import hydrogram
+from typing import TYPE_CHECKING
+
 from hydrogram.types import Identifier, Listener, ListenerTypes
+
+if TYPE_CHECKING:
+    import hydrogram
 
 
 class GetManyListenersMatchingWithData:

--- a/hydrogram/methods/pyromod/get_many_listeners_matching_with_identifier_pattern.py
+++ b/hydrogram/methods/pyromod/get_many_listeners_matching_with_identifier_pattern.py
@@ -18,8 +18,12 @@
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 
-import hydrogram
+from typing import TYPE_CHECKING
+
 from hydrogram.types import Identifier, Listener, ListenerTypes
+
+if TYPE_CHECKING:
+    import hydrogram
 
 
 class GetManyListenersMatchingWithIdentifierPattern:

--- a/hydrogram/methods/pyromod/listen.py
+++ b/hydrogram/methods/pyromod/listen.py
@@ -17,31 +17,35 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import asyncio
 import inspect
-from typing import Optional, Union
+from typing import TYPE_CHECKING
 
-import hydrogram
 from hydrogram.errors import (
     ListenerTimeout,
 )
-from hydrogram.filters import Filter
 from hydrogram.types import Identifier, Listener, ListenerTypes
 from hydrogram.utils import PyromodConfig
+
+if TYPE_CHECKING:
+    import hydrogram
+    from hydrogram.filters import Filter
 
 
 class Listen:
     async def listen(
-        self: "hydrogram.Client",
-        filters: Optional[Filter] = None,
+        self: hydrogram.Client,
+        filters: Filter | None = None,
         listener_type: ListenerTypes = ListenerTypes.MESSAGE,
-        timeout: Optional[int] = None,
+        timeout: int | None = None,
         unallowed_click_alert: bool = True,
-        chat_id: Optional[Union[int, str, list[Union[int, str]]]] = None,
-        user_id: Optional[Union[int, str, list[Union[int, str]]]] = None,
-        message_id: Optional[Union[int, list[int]]] = None,
-        inline_message_id: Optional[Union[str, list[str]]] = None,
-    ) -> Union["hydrogram.types.Message", "hydrogram.types.CallbackQuery"]:
+        chat_id: int | str | list[int | str] | None = None,
+        user_id: int | str | list[int | str] | None = None,
+        message_id: int | list[int] | None = None,
+        inline_message_id: str | list[str] | None = None,
+    ) -> hydrogram.types.Message | hydrogram.types.CallbackQuery:
         """
         Creates a listener and waits for it to be fulfilled.
 

--- a/hydrogram/methods/pyromod/register_next_step_handler.py
+++ b/hydrogram/methods/pyromod/register_next_step_handler.py
@@ -17,24 +17,28 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Callable, Optional, Union
+from __future__ import annotations
 
-import hydrogram
-from hydrogram.filters import Filter
+from typing import TYPE_CHECKING, Callable
+
 from hydrogram.types import Identifier, Listener, ListenerTypes
+
+if TYPE_CHECKING:
+    import hydrogram
+    from hydrogram.filters import Filter
 
 
 class RegisterNextStepHandler:
     def register_next_step_handler(
-        self: "hydrogram.Client",
+        self: hydrogram.Client,
         callback: Callable,
-        filters: Optional[Filter] = None,
+        filters: Filter | None = None,
         listener_type: ListenerTypes = ListenerTypes.MESSAGE,
         unallowed_click_alert: bool = True,
-        chat_id: Optional[Union[int, str, list[Union[int, str]]]] = None,
-        user_id: Optional[Union[int, str, list[Union[int, str]]]] = None,
-        message_id: Optional[Union[int, list[int]]] = None,
-        inline_message_id: Optional[Union[str, list[str]]] = None,
+        chat_id: int | str | list[int | str] | None = None,
+        user_id: int | str | list[int | str] | None = None,
+        message_id: int | list[int] | None = None,
+        inline_message_id: str | list[str] | None = None,
     ):
         """
         Registers a listener with a callback to be called when the listener is fulfilled.

--- a/hydrogram/methods/pyromod/remove_listener.py
+++ b/hydrogram/methods/pyromod/remove_listener.py
@@ -18,9 +18,12 @@
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import contextlib
+from typing import TYPE_CHECKING
 
-import hydrogram
 from hydrogram.types import Listener
+
+if TYPE_CHECKING:
+    import hydrogram
 
 
 class RemoveListener:

--- a/hydrogram/methods/pyromod/stop_listener.py
+++ b/hydrogram/methods/pyromod/stop_listener.py
@@ -18,13 +18,16 @@
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import inspect
+from typing import TYPE_CHECKING
 
-import hydrogram
 from hydrogram.errors import (
     ListenerStopped,
 )
 from hydrogram.types import Listener
 from hydrogram.utils import PyromodConfig
+
+if TYPE_CHECKING:
+    import hydrogram
 
 
 class StopListener:

--- a/hydrogram/methods/pyromod/stop_listening.py
+++ b/hydrogram/methods/pyromod/stop_listening.py
@@ -17,20 +17,24 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional, Union
+from __future__ import annotations
 
-import hydrogram
+from typing import TYPE_CHECKING
+
 from hydrogram.types import Identifier, ListenerTypes
+
+if TYPE_CHECKING:
+    import hydrogram
 
 
 class StopListening:
     async def stop_listening(
-        self: "hydrogram.Client",
+        self: hydrogram.Client,
         listener_type: ListenerTypes = ListenerTypes.MESSAGE,
-        chat_id: Optional[Union[int, str, list[Union[int, str]]]] = None,
-        user_id: Optional[Union[int, str, list[Union[int, str]]]] = None,
-        message_id: Optional[Union[int, list[int]]] = None,
-        inline_message_id: Optional[Union[str, list[str]]] = None,
+        chat_id: int | str | list[int | str] | None = None,
+        user_id: int | str | list[int | str] | None = None,
+        message_id: int | list[int] | None = None,
+        inline_message_id: str | list[str] | None = None,
     ):
         """
         Stops all listeners that match the given identifier pattern.

--- a/hydrogram/methods/users/block_user.py
+++ b/hydrogram/methods/users/block_user.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
@@ -25,9 +25,9 @@ from hydrogram import raw
 
 class BlockUser:
     async def block_user(
-        self: "hydrogram.Client",
-        user_id: Union[int, str],
-        my_stories_from: Union[bool, None] = None,
+        self: hydrogram.Client,
+        user_id: int | str,
+        my_stories_from: bool | None = None,
     ) -> bool:
         """Block a user.
 

--- a/hydrogram/methods/users/delete_profile_photos.py
+++ b/hydrogram/methods/users/delete_profile_photos.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw, utils
@@ -25,9 +25,7 @@ from hydrogram.file_id import FileType
 
 
 class DeleteProfilePhotos:
-    async def delete_profile_photos(
-        self: "hydrogram.Client", photo_ids: Union[str, list[str]]
-    ) -> bool:
+    async def delete_profile_photos(self: hydrogram.Client, photo_ids: str | list[str]) -> bool:
         """Delete your own profile photos.
 
         .. include:: /_includes/usable-by/users.rst

--- a/hydrogram/methods/users/get_chat_photos.py
+++ b/hydrogram/methods/users/get_chat_photos.py
@@ -17,19 +17,23 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from collections.abc import AsyncGenerator
-from typing import Optional, Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import hydrogram
 from hydrogram import raw, types, utils
 
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
 
 class GetChatPhotos:
     async def get_chat_photos(
-        self: "hydrogram.Client",
-        chat_id: Union[int, str],
+        self: hydrogram.Client,
+        chat_id: int | str,
         limit: int = 0,
-    ) -> Optional[AsyncGenerator["types.Photo", None]]:
+    ) -> AsyncGenerator[types.Photo, None] | None:
         """Get a chat or a user profile photos sequentially.
 
         .. include:: /_includes/usable-by/users-bots.rst

--- a/hydrogram/methods/users/get_chat_photos_count.py
+++ b/hydrogram/methods/users/get_chat_photos_count.py
@@ -17,14 +17,14 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
 
 
 class GetChatPhotosCount:
-    async def get_chat_photos_count(self: "hydrogram.Client", chat_id: Union[int, str]) -> int:
+    async def get_chat_photos_count(self: hydrogram.Client, chat_id: int | str) -> int:
         """Get the total count of photos for a chat.
 
         .. include:: /_includes/usable-by/users-bots.rst

--- a/hydrogram/methods/users/get_common_chats.py
+++ b/hydrogram/methods/users/get_common_chats.py
@@ -17,16 +17,14 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw, types
 
 
 class GetCommonChats:
-    async def get_common_chats(
-        self: "hydrogram.Client", user_id: Union[int, str]
-    ) -> list["types.Chat"]:
+    async def get_common_chats(self: hydrogram.Client, user_id: int | str) -> list[types.Chat]:
         """Get the common chats you have with a user.
 
         .. include:: /_includes/usable-by/users.rst

--- a/hydrogram/methods/users/get_users.py
+++ b/hydrogram/methods/users/get_users.py
@@ -17,18 +17,22 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import asyncio
-from collections.abc import Iterable
-from typing import Union
+from typing import TYPE_CHECKING
 
 import hydrogram
 from hydrogram import raw, types
 
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
 
 class GetUsers:
     async def get_users(
-        self: "hydrogram.Client", user_ids: Union[int, str, Iterable[Union[int, str]]]
-    ) -> Union["types.User", list["types.User"]]:
+        self: hydrogram.Client, user_ids: int | str | Iterable[int | str]
+    ) -> types.User | list[types.User]:
         """Get information about a user.
         You can retrieve up to 200 users at once.
 

--- a/hydrogram/methods/users/set_profile_photo.py
+++ b/hydrogram/methods/users/set_profile_photo.py
@@ -17,7 +17,9 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import BinaryIO, Optional, Union
+from __future__ import annotations
+
+from typing import BinaryIO
 
 import hydrogram
 from hydrogram import raw
@@ -25,9 +27,9 @@ from hydrogram import raw
 
 class SetProfilePhoto:
     async def set_profile_photo(
-        self: "hydrogram.Client",
-        photo: Optional[Union[str, BinaryIO]] = None,
-        video: Optional[Union[str, BinaryIO]] = None,
+        self: hydrogram.Client,
+        photo: str | BinaryIO | None = None,
+        video: str | BinaryIO | None = None,
     ) -> bool:
         """Set a new profile photo or video (H.264/MPEG-4 AVC video, max 5 seconds).
 

--- a/hydrogram/methods/users/set_username.py
+++ b/hydrogram/methods/users/set_username.py
@@ -17,14 +17,14 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
 
 
 class SetUsername:
-    async def set_username(self: "hydrogram.Client", username: Optional[str]) -> bool:
+    async def set_username(self: hydrogram.Client, username: str | None) -> bool:
         """Set your own username.
 
         This method only works for users, not bots. Bot usernames must be changed via Bot Support or by recreating

--- a/hydrogram/methods/users/unblock_user.py
+++ b/hydrogram/methods/users/unblock_user.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
@@ -25,9 +25,9 @@ from hydrogram import raw
 
 class UnblockUser:
     async def unblock_user(
-        self: "hydrogram.Client",
-        user_id: Union[int, str],
-        my_stories_from: Union[bool, None] = None,
+        self: hydrogram.Client,
+        user_id: int | str,
+        my_stories_from: bool | None = None,
     ) -> bool:
         """Unblock a user.
 

--- a/hydrogram/methods/users/update_profile.py
+++ b/hydrogram/methods/users/update_profile.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
@@ -25,10 +25,10 @@ from hydrogram import raw
 
 class UpdateProfile:
     async def update_profile(
-        self: "hydrogram.Client",
-        first_name: Optional[str] = None,
-        last_name: Optional[str] = None,
-        bio: Optional[str] = None,
+        self: hydrogram.Client,
+        first_name: str | None = None,
+        last_name: str | None = None,
+        bio: str | None = None,
     ) -> bool:
         """Update your profile details such as first name, last name and bio.
 

--- a/hydrogram/methods/utilities/add_handler.py
+++ b/hydrogram/methods/utilities/add_handler.py
@@ -17,9 +17,13 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-import hydrogram
+from typing import TYPE_CHECKING
+
 from hydrogram.handlers import DisconnectHandler
-from hydrogram.handlers.handler import Handler
+
+if TYPE_CHECKING:
+    import hydrogram
+    from hydrogram.handlers.handler import Handler
 
 
 class AddHandler:

--- a/hydrogram/methods/utilities/compose.py
+++ b/hydrogram/methods/utilities/compose.py
@@ -18,10 +18,12 @@
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import asyncio
-
-import hydrogram
+from typing import TYPE_CHECKING
 
 from .idle import idle
+
+if TYPE_CHECKING:
+    import hydrogram
 
 
 async def compose(clients: list["hydrogram.Client"], sequential: bool = False):

--- a/hydrogram/methods/utilities/export_session_string.py
+++ b/hydrogram/methods/utilities/export_session_string.py
@@ -17,7 +17,10 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-import hydrogram
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import hydrogram
 
 
 class ExportSessionString:

--- a/hydrogram/methods/utilities/remove_handler.py
+++ b/hydrogram/methods/utilities/remove_handler.py
@@ -17,9 +17,13 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-import hydrogram
+from typing import TYPE_CHECKING
+
 from hydrogram.handlers import DisconnectHandler
-from hydrogram.handlers.handler import Handler
+
+if TYPE_CHECKING:
+    import hydrogram
+    from hydrogram.handlers.handler import Handler
 
 
 class RemoveHandler:

--- a/hydrogram/methods/utilities/restart.py
+++ b/hydrogram/methods/utilities/restart.py
@@ -17,7 +17,10 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-import hydrogram
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import hydrogram
 
 
 class Restart:

--- a/hydrogram/methods/utilities/run.py
+++ b/hydrogram/methods/utilities/run.py
@@ -19,9 +19,12 @@
 
 import asyncio
 import inspect
+from typing import TYPE_CHECKING
 
-import hydrogram
 from hydrogram.methods.utilities.idle import idle
+
+if TYPE_CHECKING:
+    import hydrogram
 
 
 class Run:

--- a/hydrogram/methods/utilities/stop.py
+++ b/hydrogram/methods/utilities/stop.py
@@ -17,7 +17,10 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-import hydrogram
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import hydrogram
 
 
 class Stop:

--- a/hydrogram/parser/markdown.py
+++ b/hydrogram/parser/markdown.py
@@ -19,13 +19,15 @@
 
 import html
 import re
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
-import hydrogram
 from hydrogram.enums import MessageEntityType
 
 from . import utils
 from .html import HTML
+
+if TYPE_CHECKING:
+    import hydrogram
 
 BOLD_DELIM = "**"
 ITALIC_DELIM = "__"

--- a/hydrogram/parser/parser.py
+++ b/hydrogram/parser/parser.py
@@ -17,7 +17,9 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Any, Optional, Union
+from __future__ import annotations
+
+from typing import Any
 
 import hydrogram
 from hydrogram import enums
@@ -27,12 +29,12 @@ from .markdown import Markdown
 
 
 class Parser:
-    def __init__(self, client: Optional["hydrogram.Client"]):
+    def __init__(self, client: hydrogram.Client | None):
         self.client = client
         self.html = HTML(client)
         self.markdown = Markdown(client)
 
-    async def parse(self, text: Union[str, Any], mode: Optional[enums.ParseMode] = None):
+    async def parse(self, text: str | Any, mode: enums.ParseMode | None = None):
         text = text if isinstance(text, str) else str(text)
 
         if mode is None:

--- a/hydrogram/raw/core/primitives/vector.py
+++ b/hydrogram/raw/core/primitives/vector.py
@@ -17,14 +17,18 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from io import BytesIO
-from typing import Any, Union, cast
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, cast
 
 from hydrogram.raw.core.list import List
 from hydrogram.raw.core.tl_object import TLObject
 
 from .bool import Bool, BoolFalse, BoolTrue
 from .int import Int, Long
+
+if TYPE_CHECKING:
+    from io import BytesIO
 
 
 class Vector(bytes, TLObject):
@@ -33,7 +37,7 @@ class Vector(bytes, TLObject):
     # Method added to handle the special case when a query returns a bare Vector (of Ints);
     # i.e., RpcResult body starts with 0x1cb5c415 (Vector Id) - e.g., messages.GetMessagesViews.
     @staticmethod
-    def read_bare(b: BytesIO, size: int) -> Union[int, Any]:
+    def read_bare(b: BytesIO, size: int) -> int | Any:
         if size == 4:
             e = int.from_bytes(b.read(4), "little")
             b.seek(-4, 1)

--- a/hydrogram/raw/core/tl_object.py
+++ b/hydrogram/raw/core/tl_object.py
@@ -17,11 +17,15 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from io import BytesIO
+from __future__ import annotations
+
 from json import dumps
-from typing import Any, Union, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from hydrogram.raw.all import objects
+
+if TYPE_CHECKING:
+    from io import BytesIO
 
 
 class TLObject:
@@ -37,7 +41,7 @@ class TLObject:
         pass
 
     @staticmethod
-    def default(obj: "TLObject") -> Union[str, dict[str, str]]:
+    def default(obj: TLObject) -> str | dict[str, str]:
         if isinstance(obj, bytes):
             return repr(obj)
 

--- a/hydrogram/storage/sqlite_storage.py
+++ b/hydrogram/storage/sqlite_storage.py
@@ -17,12 +17,14 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import base64
 import inspect
 import struct
 import time
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 import aiosqlite
 
@@ -96,8 +98,8 @@ class SQLiteStorage(BaseStorage):
     def __init__(
         self,
         name: str,
-        workdir: Optional[Path] = None,
-        session_string: Optional[str] = None,
+        workdir: Path | None = None,
+        session_string: str | None = None,
         use_memory: bool = False,
     ):
         super().__init__(name)

--- a/hydrogram/types/authorization/sent_code.py
+++ b/hydrogram/types/authorization/sent_code.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
+from __future__ import annotations
 
 from hydrogram import enums, raw
 from hydrogram.types.object import Object
@@ -44,10 +44,10 @@ class SentCode(Object):
     def __init__(
         self,
         *,
-        type: "enums.SentCodeType",
+        type: enums.SentCodeType,
         phone_code_hash: str,
-        next_type: "enums.NextCodeType" = None,
-        timeout: Optional[int] = None,
+        next_type: enums.NextCodeType = None,
+        timeout: int | None = None,
     ):
         super().__init__()
 
@@ -57,7 +57,7 @@ class SentCode(Object):
         self.timeout = timeout
 
     @staticmethod
-    def _parse(sent_code: raw.types.auth.SentCode) -> "SentCode":
+    def _parse(sent_code: raw.types.auth.SentCode) -> SentCode:
         return SentCode(
             type=enums.SentCodeType(type(sent_code.type)),
             phone_code_hash=sent_code.phone_code_hash,

--- a/hydrogram/types/bots_and_keyboards/bot_command_scope.py
+++ b/hydrogram/types/bots_and_keyboards/bot_command_scope.py
@@ -17,9 +17,13 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-import hydrogram
-from hydrogram import raw
+from typing import TYPE_CHECKING
+
 from hydrogram.types.object import Object
+
+if TYPE_CHECKING:
+    import hydrogram
+    from hydrogram import raw
 
 
 class BotCommandScope(Object):

--- a/hydrogram/types/bots_and_keyboards/bot_command_scope_chat.py
+++ b/hydrogram/types/bots_and_keyboards/bot_command_scope_chat.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
@@ -34,10 +34,10 @@ class BotCommandScopeChat(BotCommandScope):
             @supergroupusername).
     """
 
-    def __init__(self, chat_id: Union[int, str]):
+    def __init__(self, chat_id: int | str):
         super().__init__("chat")
 
         self.chat_id = chat_id
 
-    async def write(self, client: "hydrogram.Client") -> "raw.base.BotCommandScope":
+    async def write(self, client: hydrogram.Client) -> raw.base.BotCommandScope:
         return raw.types.BotCommandScopePeer(peer=await client.resolve_peer(self.chat_id))

--- a/hydrogram/types/bots_and_keyboards/bot_command_scope_chat_administrators.py
+++ b/hydrogram/types/bots_and_keyboards/bot_command_scope_chat_administrators.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
@@ -34,10 +34,10 @@ class BotCommandScopeChatAdministrators(BotCommandScope):
             @supergroupusername).
     """
 
-    def __init__(self, chat_id: Union[int, str]):
+    def __init__(self, chat_id: int | str):
         super().__init__("chat_administrators")
 
         self.chat_id = chat_id
 
-    async def write(self, client: "hydrogram.Client") -> "raw.base.BotCommandScope":
+    async def write(self, client: hydrogram.Client) -> raw.base.BotCommandScope:
         return raw.types.BotCommandScopePeerAdmins(peer=await client.resolve_peer(self.chat_id))

--- a/hydrogram/types/bots_and_keyboards/bot_command_scope_chat_member.py
+++ b/hydrogram/types/bots_and_keyboards/bot_command_scope_chat_member.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
@@ -37,13 +37,13 @@ class BotCommandScopeChatMember(BotCommandScope):
             Unique identifier of the target user.
     """
 
-    def __init__(self, chat_id: Union[int, str], user_id: Union[int, str]):
+    def __init__(self, chat_id: int | str, user_id: int | str):
         super().__init__("chat_member")
 
         self.chat_id = chat_id
         self.user_id = user_id
 
-    async def write(self, client: "hydrogram.Client") -> "raw.base.BotCommandScope":
+    async def write(self, client: hydrogram.Client) -> raw.base.BotCommandScope:
         return raw.types.BotCommandScopePeerUser(
             peer=await client.resolve_peer(self.chat_id),
             user_id=await client.resolve_peer(self.user_id),

--- a/hydrogram/types/bots_and_keyboards/callback_query.py
+++ b/hydrogram/types/bots_and_keyboards/callback_query.py
@@ -17,13 +17,17 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from re import Match
-from typing import Optional, Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import hydrogram
 from hydrogram import enums, raw, types, utils
 from hydrogram.types.object import Object
 from hydrogram.types.update import Update
+
+if TYPE_CHECKING:
+    from re import Match
 
 
 class CallbackQuery(Object, Update):
@@ -65,15 +69,15 @@ class CallbackQuery(Object, Update):
     def __init__(
         self,
         *,
-        client: "hydrogram.Client" = None,
+        client: hydrogram.Client = None,
         id: str,
-        from_user: "types.User",
+        from_user: types.User,
         chat_instance: str,
-        message: "types.Message" = None,
-        inline_message_id: Optional[str] = None,
-        data: Optional[Union[str, bytes]] = None,
-        game_short_name: Optional[str] = None,
-        matches: Optional[list[Match]] = None,
+        message: types.Message = None,
+        inline_message_id: str | None = None,
+        data: str | bytes | None = None,
+        game_short_name: str | None = None,
+        matches: list[Match] | None = None,
     ):
         super().__init__(client)
 
@@ -87,7 +91,7 @@ class CallbackQuery(Object, Update):
         self.matches = matches
 
     @staticmethod
-    async def _parse(client: "hydrogram.Client", callback_query, users) -> "CallbackQuery":
+    async def _parse(client: hydrogram.Client, callback_query, users) -> CallbackQuery:
         message = None
         inline_message_id = None
 
@@ -121,9 +125,9 @@ class CallbackQuery(Object, Update):
 
     async def answer(
         self,
-        text: Optional[str] = None,
-        show_alert: Optional[bool] = None,
-        url: Optional[str] = None,
+        text: str | None = None,
+        show_alert: bool | None = None,
+        url: str | None = None,
         cache_time: int = 0,
     ):
         """Bound method *answer* of :obj:`~hydrogram.types.CallbackQuery`.
@@ -168,10 +172,10 @@ class CallbackQuery(Object, Update):
     async def edit_message_text(
         self,
         text: str,
-        parse_mode: Optional["enums.ParseMode"] = None,
-        disable_web_page_preview: Optional[bool] = None,
-        reply_markup: "types.InlineKeyboardMarkup" = None,
-    ) -> Union["types.Message", bool]:
+        parse_mode: enums.ParseMode | None = None,
+        disable_web_page_preview: bool | None = None,
+        reply_markup: types.InlineKeyboardMarkup = None,
+    ) -> types.Message | bool:
         """Edit the text of messages attached to callback queries.
 
         Bound method *edit_message_text* of :obj:`~hydrogram.types.CallbackQuery`.
@@ -217,9 +221,9 @@ class CallbackQuery(Object, Update):
     async def edit_message_caption(
         self,
         caption: str,
-        parse_mode: Optional["enums.ParseMode"] = None,
-        reply_markup: "types.InlineKeyboardMarkup" = None,
-    ) -> Union["types.Message", bool]:
+        parse_mode: enums.ParseMode | None = None,
+        reply_markup: types.InlineKeyboardMarkup = None,
+    ) -> types.Message | bool:
         """Edit the caption of media messages attached to callback queries.
 
         Bound method *edit_message_caption* of :obj:`~hydrogram.types.CallbackQuery`.
@@ -246,9 +250,9 @@ class CallbackQuery(Object, Update):
 
     async def edit_message_media(
         self,
-        media: "types.InputMedia",
-        reply_markup: "types.InlineKeyboardMarkup" = None,
-    ) -> Union["types.Message", bool]:
+        media: types.InputMedia,
+        reply_markup: types.InlineKeyboardMarkup = None,
+    ) -> types.Message | bool:
         """Edit animation, audio, document, photo or video messages attached to callback queries.
 
         Bound method *edit_message_media* of :obj:`~hydrogram.types.CallbackQuery`.
@@ -281,8 +285,8 @@ class CallbackQuery(Object, Update):
         )
 
     async def edit_message_reply_markup(
-        self, reply_markup: "types.InlineKeyboardMarkup" = None
-    ) -> Union["types.Message", bool]:
+        self, reply_markup: types.InlineKeyboardMarkup = None
+    ) -> types.Message | bool:
         """Edit only the reply markup of messages attached to callback queries.
 
         Bound method *edit_message_reply_markup* of :obj:`~hydrogram.types.CallbackQuery`.

--- a/hydrogram/types/bots_and_keyboards/force_reply.py
+++ b/hydrogram/types/bots_and_keyboards/force_reply.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
@@ -43,7 +43,7 @@ class ForceReply(Object):
             The placeholder to be shown in the input field when the reply is active; 1-64 characters.
     """
 
-    def __init__(self, selective: Optional[bool] = None, placeholder: Optional[str] = None):
+    def __init__(self, selective: bool | None = None, placeholder: str | None = None):
         super().__init__()
 
         self.selective = selective
@@ -53,7 +53,7 @@ class ForceReply(Object):
     def read(b):
         return ForceReply(selective=b.selective, placeholder=b.placeholder)
 
-    async def write(self, _: "hydrogram.Client"):
+    async def write(self, _: hydrogram.Client):
         return raw.types.ReplyKeyboardForceReply(
             single_use=True,
             selective=self.selective or None,

--- a/hydrogram/types/bots_and_keyboards/game_high_score.py
+++ b/hydrogram/types/bots_and_keyboards/game_high_score.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw, types, utils
@@ -41,10 +41,10 @@ class GameHighScore(Object):
     def __init__(
         self,
         *,
-        client: "hydrogram.Client" = None,
-        user: "types.User",
+        client: hydrogram.Client = None,
+        user: types.User,
         score: int,
-        position: Optional[int] = None,
+        position: int | None = None,
     ):
         super().__init__(client)
 
@@ -53,7 +53,7 @@ class GameHighScore(Object):
         self.position = position
 
     @staticmethod
-    def _parse(client, game_high_score: raw.types.HighScore, users: dict) -> "GameHighScore":
+    def _parse(client, game_high_score: raw.types.HighScore, users: dict) -> GameHighScore:
         users = {i.id: i for i in users}
 
         return GameHighScore(

--- a/hydrogram/types/bots_and_keyboards/inline_keyboard_button.py
+++ b/hydrogram/types/bots_and_keyboards/inline_keyboard_button.py
@@ -17,7 +17,9 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Any, Optional, Union
+from __future__ import annotations
+
+from typing import Any
 
 import hydrogram
 from hydrogram import raw, types
@@ -73,15 +75,15 @@ class InlineKeyboardButton(Object):
 
     def __init__(
         self,
-        text: Union[str, Any],
-        callback_data: Optional[Union[str, bytes]] = None,
-        url: Optional[str] = None,
-        web_app: "types.WebAppInfo" = None,
-        login_url: "types.LoginUrl" = None,
-        user_id: Optional[int] = None,
-        switch_inline_query: Optional[str] = None,
-        switch_inline_query_current_chat: Optional[str] = None,
-        callback_game: "types.CallbackGame" = None,
+        text: str | Any,
+        callback_data: str | bytes | None = None,
+        url: str | None = None,
+        web_app: types.WebAppInfo = None,
+        login_url: types.LoginUrl = None,
+        user_id: int | None = None,
+        switch_inline_query: str | None = None,
+        switch_inline_query_current_chat: str | None = None,
+        callback_game: types.CallbackGame = None,
     ):
         super().__init__()
 
@@ -97,7 +99,7 @@ class InlineKeyboardButton(Object):
         # self.pay = pay
 
     @staticmethod
-    def read(b: "raw.base.KeyboardButton"):
+    def read(b: raw.base.KeyboardButton):
         if isinstance(b, raw.types.KeyboardButtonCallback):
             # Try decode data to keep it as string, but if fails, fallback to bytes so we don't lose any information,
             # instead of decoding by ignoring/replacing errors.
@@ -129,7 +131,7 @@ class InlineKeyboardButton(Object):
             return InlineKeyboardButton(text=b.text, web_app=types.WebAppInfo(url=b.url))
         return None
 
-    async def write(self, client: "hydrogram.Client"):
+    async def write(self, client: hydrogram.Client):
         if self.callback_data is not None:
             # Telegram only wants bytes, but we are allowed to pass strings too, for convenience.
             data = (

--- a/hydrogram/types/bots_and_keyboards/keyboard_button.py
+++ b/hydrogram/types/bots_and_keyboards/keyboard_button.py
@@ -17,7 +17,9 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Any, Optional, Union
+from __future__ import annotations
+
+from typing import Any
 
 from hydrogram import raw, types
 from hydrogram.types.object import Object
@@ -50,10 +52,10 @@ class KeyboardButton(Object):
 
     def __init__(
         self,
-        text: Union[str, Any],
-        request_contact: Optional[bool] = None,
-        request_location: Optional[bool] = None,
-        web_app: "types.WebAppInfo" = None,
+        text: str | Any,
+        request_contact: bool | None = None,
+        request_location: bool | None = None,
+        web_app: types.WebAppInfo = None,
     ):
         super().__init__()
 

--- a/hydrogram/types/bots_and_keyboards/login_url.py
+++ b/hydrogram/types/bots_and_keyboards/login_url.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
+from __future__ import annotations
 
 from hydrogram import raw
 from hydrogram.types.object import Object
@@ -62,10 +62,10 @@ class LoginUrl(Object):
         self,
         *,
         url: str,
-        forward_text: Optional[str] = None,
-        bot_username: Optional[str] = None,
-        request_write_access: Optional[str] = None,
-        button_id: Optional[int] = None,
+        forward_text: str | None = None,
+        bot_username: str | None = None,
+        request_write_access: str | None = None,
+        button_id: int | None = None,
     ):
         super().__init__()
 
@@ -76,10 +76,10 @@ class LoginUrl(Object):
         self.button_id = button_id
 
     @staticmethod
-    def read(b: "raw.types.KeyboardButtonUrlAuth") -> "LoginUrl":
+    def read(b: raw.types.KeyboardButtonUrlAuth) -> LoginUrl:
         return LoginUrl(url=b.url, forward_text=b.fwd_text, button_id=b.button_id)
 
-    def write(self, text: str, bot: "raw.types.InputUser"):
+    def write(self, text: str, bot: raw.types.InputUser):
         return raw.types.InputKeyboardButtonUrlAuth(
             text=text,
             url=self.url,

--- a/hydrogram/types/bots_and_keyboards/menu_button.py
+++ b/hydrogram/types/bots_and_keyboards/menu_button.py
@@ -17,9 +17,13 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-import hydrogram
-from hydrogram import raw
+from typing import TYPE_CHECKING
+
 from hydrogram.types.object import Object
+
+if TYPE_CHECKING:
+    import hydrogram
+    from hydrogram import raw
 
 
 class MenuButton(Object):

--- a/hydrogram/types/bots_and_keyboards/reply_keyboard_markup.py
+++ b/hydrogram/types/bots_and_keyboards/reply_keyboard_markup.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional, Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw, types
@@ -58,12 +58,12 @@ class ReplyKeyboardMarkup(Object):
 
     def __init__(
         self,
-        keyboard: list[list[Union["types.KeyboardButton", str]]],
-        is_persistent: Optional[bool] = None,
-        resize_keyboard: Optional[bool] = None,
-        one_time_keyboard: Optional[bool] = None,
-        selective: Optional[bool] = None,
-        placeholder: Optional[str] = None,
+        keyboard: list[list[types.KeyboardButton | str]],
+        is_persistent: bool | None = None,
+        resize_keyboard: bool | None = None,
+        one_time_keyboard: bool | None = None,
+        selective: bool | None = None,
+        placeholder: str | None = None,
     ):
         super().__init__()
 
@@ -75,7 +75,7 @@ class ReplyKeyboardMarkup(Object):
         self.placeholder = placeholder
 
     @staticmethod
-    def read(kb: "raw.base.ReplyMarkup"):
+    def read(kb: raw.base.ReplyMarkup):
         keyboard = []
 
         for i in kb.rows:
@@ -91,7 +91,7 @@ class ReplyKeyboardMarkup(Object):
             placeholder=kb.placeholder,
         )
 
-    async def write(self, _: "hydrogram.Client"):
+    async def write(self, _: hydrogram.Client):
         return raw.types.ReplyKeyboardMarkup(
             rows=[
                 raw.types.KeyboardButtonRow(

--- a/hydrogram/types/bots_and_keyboards/reply_keyboard_remove.py
+++ b/hydrogram/types/bots_and_keyboards/reply_keyboard_remove.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
@@ -41,7 +41,7 @@ class ReplyKeyboardRemove(Object):
             keyboard for that user, while still showing the keyboard with poll options to users who haven't voted yet.
     """
 
-    def __init__(self, selective: Optional[bool] = None):
+    def __init__(self, selective: bool | None = None):
         super().__init__()
 
         self.selective = selective
@@ -50,5 +50,5 @@ class ReplyKeyboardRemove(Object):
     def read(b):
         return ReplyKeyboardRemove(selective=b.selective)
 
-    async def write(self, _: "hydrogram.Client"):
+    async def write(self, _: hydrogram.Client):
         return raw.types.ReplyKeyboardHide(selective=self.selective or None)

--- a/hydrogram/types/inline_mode/chosen_inline_result.py
+++ b/hydrogram/types/inline_mode/chosen_inline_result.py
@@ -17,9 +17,10 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 from base64 import b64encode
 from struct import pack
-from typing import Optional
 
 import hydrogram
 from hydrogram import raw, types
@@ -57,12 +58,12 @@ class ChosenInlineResult(Object, Update):
     def __init__(
         self,
         *,
-        client: "hydrogram.Client" = None,
+        client: hydrogram.Client = None,
         result_id: str,
-        from_user: "types.User",
+        from_user: types.User,
         query: str,
-        location: "types.Location" = None,
-        inline_message_id: Optional[str] = None,
+        location: types.Location = None,
+        inline_message_id: str | None = None,
     ):
         super().__init__(client)
 
@@ -75,7 +76,7 @@ class ChosenInlineResult(Object, Update):
     @staticmethod
     def _parse(
         client, chosen_inline_result: raw.types.UpdateBotInlineSend, users
-    ) -> "ChosenInlineResult":
+    ) -> ChosenInlineResult:
         inline_message_id = None
 
         if isinstance(chosen_inline_result.msg_id, raw.types.InputBotInlineMessageID):

--- a/hydrogram/types/inline_mode/inline_query.py
+++ b/hydrogram/types/inline_mode/inline_query.py
@@ -17,13 +17,17 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from re import Match
-from typing import Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import hydrogram
 from hydrogram import enums, raw, types
 from hydrogram.types.object import Object
 from hydrogram.types.update import Update
+
+if TYPE_CHECKING:
+    from re import Match
 
 
 class InlineQuery(Object, Update):
@@ -58,14 +62,14 @@ class InlineQuery(Object, Update):
     def __init__(
         self,
         *,
-        client: "hydrogram.Client" = None,
+        client: hydrogram.Client = None,
         id: str,
-        from_user: "types.User",
+        from_user: types.User,
         query: str,
         offset: str,
-        chat_type: "enums.ChatType",
-        location: "types.Location" = None,
-        matches: Optional[list[Match]] = None,
+        chat_type: enums.ChatType,
+        location: types.Location = None,
+        matches: list[Match] | None = None,
     ):
         super().__init__(client)
 
@@ -78,7 +82,7 @@ class InlineQuery(Object, Update):
         self.matches = matches
 
     @staticmethod
-    def _parse(client, inline_query: raw.types.UpdateBotInlineQuery, users: dict) -> "InlineQuery":
+    def _parse(client, inline_query: raw.types.UpdateBotInlineQuery, users: dict) -> InlineQuery:
         peer_type = inline_query.peer_type
         chat_type = None
 
@@ -111,7 +115,7 @@ class InlineQuery(Object, Update):
 
     async def answer(
         self,
-        results: list["types.InlineQueryResult"],
+        results: list[types.InlineQueryResult],
         cache_time: int = 300,
         is_gallery: bool = False,
         is_personal: bool = False,

--- a/hydrogram/types/inline_mode/inline_query_result.py
+++ b/hydrogram/types/inline_mode/inline_query_result.py
@@ -17,12 +17,16 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Any, Optional, Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
-import hydrogram
-from hydrogram import types
 from hydrogram.types.object import Object
+
+if TYPE_CHECKING:
+    import hydrogram
+    from hydrogram import types
 
 
 class InlineQueryResult(Object):
@@ -50,9 +54,9 @@ class InlineQueryResult(Object):
     def __init__(
         self,
         type: str,
-        id: Optional[Union[str, Any]],
-        input_message_content: "types.InputMessageContent",
-        reply_markup: "types.InlineKeyboardMarkup",
+        id: str | Any | None,
+        input_message_content: types.InputMessageContent,
+        reply_markup: types.InlineKeyboardMarkup,
     ):
         super().__init__()
 
@@ -61,5 +65,5 @@ class InlineQueryResult(Object):
         self.input_message_content = input_message_content
         self.reply_markup = reply_markup
 
-    async def write(self, client: "hydrogram.Client"):
+    async def write(self, client: hydrogram.Client):
         pass

--- a/hydrogram/types/inline_mode/inline_query_result_animation.py
+++ b/hydrogram/types/inline_mode/inline_query_result_animation.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import enums, raw, types, utils
@@ -84,16 +84,16 @@ class InlineQueryResultAnimation(InlineQueryResult):
         animation_width: int = 0,
         animation_height: int = 0,
         animation_duration: int = 0,
-        thumb_url: Optional[str] = None,
+        thumb_url: str | None = None,
         thumb_mime_type: str = "image/jpeg",
-        id: Optional[str] = None,
-        title: Optional[str] = None,
-        description: Optional[str] = None,
+        id: str | None = None,
+        title: str | None = None,
+        description: str | None = None,
         caption: str = "",
-        parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: Optional[list["types.MessageEntity"]] = None,
-        reply_markup: "types.InlineKeyboardMarkup" = None,
-        input_message_content: "types.InputMessageContent" = None,
+        parse_mode: enums.ParseMode | None = None,
+        caption_entities: list[types.MessageEntity] | None = None,
+        reply_markup: types.InlineKeyboardMarkup = None,
+        input_message_content: types.InputMessageContent = None,
     ):
         super().__init__("gif", id, input_message_content, reply_markup)
 
@@ -111,7 +111,7 @@ class InlineQueryResultAnimation(InlineQueryResult):
         self.reply_markup = reply_markup
         self.input_message_content = input_message_content
 
-    async def write(self, client: "hydrogram.Client"):
+    async def write(self, client: hydrogram.Client):
         animation = raw.types.InputWebDocument(
             url=self.animation_url,
             size=0,

--- a/hydrogram/types/inline_mode/inline_query_result_article.py
+++ b/hydrogram/types/inline_mode/inline_query_result_article.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw, types
@@ -61,12 +61,12 @@ class InlineQueryResultArticle(InlineQueryResult):
     def __init__(
         self,
         title: str,
-        input_message_content: "types.InputMessageContent",
-        id: Optional[str] = None,
-        url: Optional[str] = None,
-        description: Optional[str] = None,
-        reply_markup: "types.InlineKeyboardMarkup" = None,
-        thumb_url: Optional[str] = None,
+        input_message_content: types.InputMessageContent,
+        id: str | None = None,
+        url: str | None = None,
+        description: str | None = None,
+        reply_markup: types.InlineKeyboardMarkup = None,
+        thumb_url: str | None = None,
         thumb_width: int = 0,
         thumb_height: int = 0,
     ):
@@ -79,7 +79,7 @@ class InlineQueryResultArticle(InlineQueryResult):
         self.thumb_width = thumb_width
         self.thumb_height = thumb_height
 
-    async def write(self, client: "hydrogram.Client"):
+    async def write(self, client: hydrogram.Client):
         return raw.types.InputBotInlineResult(
             id=self.id,
             type=self.type,

--- a/hydrogram/types/inline_mode/inline_query_result_audio.py
+++ b/hydrogram/types/inline_mode/inline_query_result_audio.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import enums, raw, types, utils
@@ -70,14 +70,14 @@ class InlineQueryResultAudio(InlineQueryResult):
         self,
         audio_url: str,
         title: str,
-        id: Optional[str] = None,
+        id: str | None = None,
         performer: str = "",
         audio_duration: int = 0,
         caption: str = "",
-        parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: Optional[list["types.MessageEntity"]] = None,
-        reply_markup: "types.InlineKeyboardMarkup" = None,
-        input_message_content: "types.InputMessageContent" = None,
+        parse_mode: enums.ParseMode | None = None,
+        caption_entities: list[types.MessageEntity] | None = None,
+        reply_markup: types.InlineKeyboardMarkup = None,
+        input_message_content: types.InputMessageContent = None,
     ):
         super().__init__("audio", id, input_message_content, reply_markup)
 
@@ -89,7 +89,7 @@ class InlineQueryResultAudio(InlineQueryResult):
         self.parse_mode = parse_mode
         self.caption_entities = caption_entities
 
-    async def write(self, client: "hydrogram.Client"):
+    async def write(self, client: hydrogram.Client):
         audio = raw.types.InputWebDocument(
             url=self.audio_url,
             size=0,

--- a/hydrogram/types/inline_mode/inline_query_result_cached_animation.py
+++ b/hydrogram/types/inline_mode/inline_query_result_cached_animation.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import enums, raw, types, utils
@@ -64,13 +64,13 @@ class InlineQueryResultCachedAnimation(InlineQueryResult):
     def __init__(
         self,
         animation_file_id: str,
-        id: Optional[str] = None,
-        title: Optional[str] = None,
+        id: str | None = None,
+        title: str | None = None,
         caption: str = "",
-        parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: Optional[list["types.MessageEntity"]] = None,
-        reply_markup: "types.InlineKeyboardMarkup" = None,
-        input_message_content: "types.InputMessageContent" = None,
+        parse_mode: enums.ParseMode | None = None,
+        caption_entities: list[types.MessageEntity] | None = None,
+        reply_markup: types.InlineKeyboardMarkup = None,
+        input_message_content: types.InputMessageContent = None,
     ):
         super().__init__("gif", id, input_message_content, reply_markup)
 
@@ -82,7 +82,7 @@ class InlineQueryResultCachedAnimation(InlineQueryResult):
         self.reply_markup = reply_markup
         self.input_message_content = input_message_content
 
-    async def write(self, client: "hydrogram.Client"):
+    async def write(self, client: hydrogram.Client):
         message, entities = (
             await utils.parse_text_entities(
                 client, self.caption, self.parse_mode, self.caption_entities

--- a/hydrogram/types/inline_mode/inline_query_result_cached_audio.py
+++ b/hydrogram/types/inline_mode/inline_query_result_cached_audio.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import enums, raw, types, utils
@@ -60,12 +60,12 @@ class InlineQueryResultCachedAudio(InlineQueryResult):
     def __init__(
         self,
         audio_file_id: str,
-        id: Optional[str] = None,
+        id: str | None = None,
         caption: str = "",
-        parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: Optional[list["types.MessageEntity"]] = None,
-        reply_markup: "types.InlineKeyboardMarkup" = None,
-        input_message_content: "types.InputMessageContent" = None,
+        parse_mode: enums.ParseMode | None = None,
+        caption_entities: list[types.MessageEntity] | None = None,
+        reply_markup: types.InlineKeyboardMarkup = None,
+        input_message_content: types.InputMessageContent = None,
     ):
         super().__init__("audio", id, input_message_content, reply_markup)
 
@@ -76,7 +76,7 @@ class InlineQueryResultCachedAudio(InlineQueryResult):
         self.reply_markup = reply_markup
         self.input_message_content = input_message_content
 
-    async def write(self, client: "hydrogram.Client"):
+    async def write(self, client: hydrogram.Client):
         message, entities = (
             await utils.parse_text_entities(
                 client, self.caption, self.parse_mode, self.caption_entities

--- a/hydrogram/types/inline_mode/inline_query_result_cached_document.py
+++ b/hydrogram/types/inline_mode/inline_query_result_cached_document.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import enums, raw, types, utils
@@ -67,13 +67,13 @@ class InlineQueryResultCachedDocument(InlineQueryResult):
         self,
         document_file_id: str,
         title: str,
-        id: Optional[str] = None,
-        description: Optional[str] = None,
+        id: str | None = None,
+        description: str | None = None,
         caption: str = "",
-        parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: Optional[list["types.MessageEntity"]] = None,
-        reply_markup: "types.InlineKeyboardMarkup" = None,
-        input_message_content: "types.InputMessageContent" = None,
+        parse_mode: enums.ParseMode | None = None,
+        caption_entities: list[types.MessageEntity] | None = None,
+        reply_markup: types.InlineKeyboardMarkup = None,
+        input_message_content: types.InputMessageContent = None,
     ):
         super().__init__("file", id, input_message_content, reply_markup)
 
@@ -86,7 +86,7 @@ class InlineQueryResultCachedDocument(InlineQueryResult):
         self.reply_markup = reply_markup
         self.input_message_content = input_message_content
 
-    async def write(self, client: "hydrogram.Client"):
+    async def write(self, client: hydrogram.Client):
         message, entities = (
             await utils.parse_text_entities(
                 client, self.caption, self.parse_mode, self.caption_entities

--- a/hydrogram/types/inline_mode/inline_query_result_cached_photo.py
+++ b/hydrogram/types/inline_mode/inline_query_result_cached_photo.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import enums, raw, types, utils
@@ -66,14 +66,14 @@ class InlineQueryResultCachedPhoto(InlineQueryResult):
     def __init__(
         self,
         photo_file_id: str,
-        id: Optional[str] = None,
-        title: Optional[str] = None,
-        description: Optional[str] = None,
+        id: str | None = None,
+        title: str | None = None,
+        description: str | None = None,
         caption: str = "",
-        parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: Optional[list["types.MessageEntity"]] = None,
-        reply_markup: "types.InlineKeyboardMarkup" = None,
-        input_message_content: "types.InputMessageContent" = None,
+        parse_mode: enums.ParseMode | None = None,
+        caption_entities: list[types.MessageEntity] | None = None,
+        reply_markup: types.InlineKeyboardMarkup = None,
+        input_message_content: types.InputMessageContent = None,
     ):
         super().__init__("photo", id, input_message_content, reply_markup)
 
@@ -86,7 +86,7 @@ class InlineQueryResultCachedPhoto(InlineQueryResult):
         self.reply_markup = reply_markup
         self.input_message_content = input_message_content
 
-    async def write(self, client: "hydrogram.Client"):
+    async def write(self, client: hydrogram.Client):
         message, entities = (
             await utils.parse_text_entities(
                 client, self.caption, self.parse_mode, self.caption_entities

--- a/hydrogram/types/inline_mode/inline_query_result_cached_sticker.py
+++ b/hydrogram/types/inline_mode/inline_query_result_cached_sticker.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw, types
@@ -50,9 +50,9 @@ class InlineQueryResultCachedSticker(InlineQueryResult):
     def __init__(
         self,
         sticker_file_id: str,
-        id: Optional[str] = None,
-        reply_markup: "types.InlineKeyboardMarkup" = None,
-        input_message_content: "types.InputMessageContent" = None,
+        id: str | None = None,
+        reply_markup: types.InlineKeyboardMarkup = None,
+        input_message_content: types.InputMessageContent = None,
     ):
         super().__init__("sticker", id, input_message_content, reply_markup)
 
@@ -60,7 +60,7 @@ class InlineQueryResultCachedSticker(InlineQueryResult):
         self.reply_markup = reply_markup
         self.input_message_content = input_message_content
 
-    async def write(self, client: "hydrogram.Client"):
+    async def write(self, client: hydrogram.Client):
         file_id = FileId.decode(self.sticker_file_id)
 
         return raw.types.InputBotInlineResultDocument(

--- a/hydrogram/types/inline_mode/inline_query_result_cached_video.py
+++ b/hydrogram/types/inline_mode/inline_query_result_cached_video.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import enums, raw, types, utils
@@ -68,13 +68,13 @@ class InlineQueryResultCachedVideo(InlineQueryResult):
         self,
         video_file_id: str,
         title: str,
-        id: Optional[str] = None,
-        description: Optional[str] = None,
+        id: str | None = None,
+        description: str | None = None,
         caption: str = "",
-        parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: Optional[list["types.MessageEntity"]] = None,
-        reply_markup: "types.InlineKeyboardMarkup" = None,
-        input_message_content: "types.InputMessageContent" = None,
+        parse_mode: enums.ParseMode | None = None,
+        caption_entities: list[types.MessageEntity] | None = None,
+        reply_markup: types.InlineKeyboardMarkup = None,
+        input_message_content: types.InputMessageContent = None,
     ):
         super().__init__("video", id, input_message_content, reply_markup)
 
@@ -87,7 +87,7 @@ class InlineQueryResultCachedVideo(InlineQueryResult):
         self.reply_markup = reply_markup
         self.input_message_content = input_message_content
 
-    async def write(self, client: "hydrogram.Client"):
+    async def write(self, client: hydrogram.Client):
         message, entities = (
             await utils.parse_text_entities(
                 client, self.caption, self.parse_mode, self.caption_entities

--- a/hydrogram/types/inline_mode/inline_query_result_cached_voice.py
+++ b/hydrogram/types/inline_mode/inline_query_result_cached_voice.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import enums, raw, types, utils
@@ -64,13 +64,13 @@ class InlineQueryResultCachedVoice(InlineQueryResult):
     def __init__(
         self,
         voice_file_id: str,
-        id: Optional[str] = None,
-        title: Optional[str] = None,
+        id: str | None = None,
+        title: str | None = None,
         caption: str = "",
-        parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: Optional[list["types.MessageEntity"]] = None,
-        reply_markup: "types.InlineKeyboardMarkup" = None,
-        input_message_content: "types.InputMessageContent" = None,
+        parse_mode: enums.ParseMode | None = None,
+        caption_entities: list[types.MessageEntity] | None = None,
+        reply_markup: types.InlineKeyboardMarkup = None,
+        input_message_content: types.InputMessageContent = None,
     ):
         super().__init__("voice", id, input_message_content, reply_markup)
 
@@ -82,7 +82,7 @@ class InlineQueryResultCachedVoice(InlineQueryResult):
         self.reply_markup = reply_markup
         self.input_message_content = input_message_content
 
-    async def write(self, client: "hydrogram.Client"):
+    async def write(self, client: hydrogram.Client):
         message, entities = (
             await utils.parse_text_entities(
                 client, self.caption, self.parse_mode, self.caption_entities

--- a/hydrogram/types/inline_mode/inline_query_result_contact.py
+++ b/hydrogram/types/inline_mode/inline_query_result_contact.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw, types
@@ -71,10 +71,10 @@ class InlineQueryResultContact(InlineQueryResult):
         first_name: str,
         last_name: str = "",
         vcard: str = "",
-        id: Optional[str] = None,
-        reply_markup: "types.InlineKeyboardMarkup" = None,
-        input_message_content: "types.InputMessageContent" = None,
-        thumb_url: Optional[str] = None,
+        id: str | None = None,
+        reply_markup: types.InlineKeyboardMarkup = None,
+        input_message_content: types.InputMessageContent = None,
+        thumb_url: str | None = None,
         thumb_width: int = 0,
         thumb_height: int = 0,
     ):
@@ -88,7 +88,7 @@ class InlineQueryResultContact(InlineQueryResult):
         self.thumb_width = thumb_width
         self.thumb_height = thumb_height
 
-    async def write(self, client: "hydrogram.Client"):
+    async def write(self, client: hydrogram.Client):
         return raw.types.InputBotInlineResult(
             id=self.id,
             type=self.type,

--- a/hydrogram/types/inline_mode/inline_query_result_document.py
+++ b/hydrogram/types/inline_mode/inline_query_result_document.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import enums, raw, types, utils
@@ -80,14 +80,14 @@ class InlineQueryResultDocument(InlineQueryResult):
         document_url: str,
         title: str,
         mime_type: str = "application/zip",
-        id: Optional[str] = None,
+        id: str | None = None,
         caption: str = "",
-        parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: Optional[list["types.MessageEntity"]] = None,
+        parse_mode: enums.ParseMode | None = None,
+        caption_entities: list[types.MessageEntity] | None = None,
         description: str = "",
-        reply_markup: "types.InlineKeyboardMarkup" = None,
-        input_message_content: "types.InputMessageContent" = None,
-        thumb_url: Optional[str] = None,
+        reply_markup: types.InlineKeyboardMarkup = None,
+        input_message_content: types.InputMessageContent = None,
+        thumb_url: str | None = None,
         thumb_width: int = 0,
         thumb_height: int = 0,
     ):
@@ -104,7 +104,7 @@ class InlineQueryResultDocument(InlineQueryResult):
         self.thumb_width = thumb_width
         self.thumb_height = thumb_height
 
-    async def write(self, client: "hydrogram.Client"):
+    async def write(self, client: hydrogram.Client):
         document = raw.types.InputWebDocument(
             url=self.document_url, size=0, mime_type=self.mime_type, attributes=[]
         )

--- a/hydrogram/types/inline_mode/inline_query_result_location.py
+++ b/hydrogram/types/inline_mode/inline_query_result_location.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw, types
@@ -80,14 +80,14 @@ class InlineQueryResultLocation(InlineQueryResult):
         title: str,
         latitude: float,
         longitude: float,
-        horizontal_accuracy: Optional[float] = None,
-        live_period: Optional[int] = None,
-        heading: Optional[int] = None,
-        proximity_alert_radius: Optional[int] = None,
-        id: Optional[str] = None,
-        reply_markup: "types.InlineKeyboardMarkup" = None,
-        input_message_content: "types.InputMessageContent" = None,
-        thumb_url: Optional[str] = None,
+        horizontal_accuracy: float | None = None,
+        live_period: int | None = None,
+        heading: int | None = None,
+        proximity_alert_radius: int | None = None,
+        id: str | None = None,
+        reply_markup: types.InlineKeyboardMarkup = None,
+        input_message_content: types.InputMessageContent = None,
+        thumb_url: str | None = None,
         thumb_width: int = 0,
         thumb_height: int = 0,
     ):
@@ -104,7 +104,7 @@ class InlineQueryResultLocation(InlineQueryResult):
         self.thumb_width = thumb_width
         self.thumb_height = thumb_height
 
-    async def write(self, client: "hydrogram.Client"):
+    async def write(self, client: hydrogram.Client):
         return raw.types.InputBotInlineResult(
             id=self.id,
             type=self.type,

--- a/hydrogram/types/inline_mode/inline_query_result_photo.py
+++ b/hydrogram/types/inline_mode/inline_query_result_photo.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import enums, raw, types, utils
@@ -77,17 +77,17 @@ class InlineQueryResultPhoto(InlineQueryResult):
     def __init__(
         self,
         photo_url: str,
-        thumb_url: Optional[str] = None,
+        thumb_url: str | None = None,
         photo_width: int = 0,
         photo_height: int = 0,
-        id: Optional[str] = None,
-        title: Optional[str] = None,
-        description: Optional[str] = None,
+        id: str | None = None,
+        title: str | None = None,
+        description: str | None = None,
         caption: str = "",
-        parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: Optional[list["types.MessageEntity"]] = None,
-        reply_markup: "types.InlineKeyboardMarkup" = None,
-        input_message_content: "types.InputMessageContent" = None,
+        parse_mode: enums.ParseMode | None = None,
+        caption_entities: list[types.MessageEntity] | None = None,
+        reply_markup: types.InlineKeyboardMarkup = None,
+        input_message_content: types.InputMessageContent = None,
     ):
         super().__init__("photo", id, input_message_content, reply_markup)
 
@@ -103,7 +103,7 @@ class InlineQueryResultPhoto(InlineQueryResult):
         self.reply_markup = reply_markup
         self.input_message_content = input_message_content
 
-    async def write(self, client: "hydrogram.Client"):
+    async def write(self, client: hydrogram.Client):
         photo = raw.types.InputWebDocument(
             url=self.photo_url,
             size=0,

--- a/hydrogram/types/inline_mode/inline_query_result_venue.py
+++ b/hydrogram/types/inline_mode/inline_query_result_venue.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw, types
@@ -82,14 +82,14 @@ class InlineQueryResultVenue(InlineQueryResult):
         address: str,
         latitude: float,
         longitude: float,
-        id: Optional[str] = None,
-        foursquare_id: Optional[str] = None,
-        foursquare_type: Optional[str] = None,
-        google_place_id: Optional[str] = None,
-        google_place_type: Optional[str] = None,
-        reply_markup: "types.InlineKeyboardMarkup" = None,
-        input_message_content: "types.InputMessageContent" = None,
-        thumb_url: Optional[str] = None,
+        id: str | None = None,
+        foursquare_id: str | None = None,
+        foursquare_type: str | None = None,
+        google_place_id: str | None = None,
+        google_place_type: str | None = None,
+        reply_markup: types.InlineKeyboardMarkup = None,
+        input_message_content: types.InputMessageContent = None,
+        thumb_url: str | None = None,
         thumb_width: int = 0,
         thumb_height: int = 0,
     ):
@@ -107,7 +107,7 @@ class InlineQueryResultVenue(InlineQueryResult):
         self.thumb_width = thumb_width
         self.thumb_height = thumb_height
 
-    async def write(self, client: "hydrogram.Client"):
+    async def write(self, client: hydrogram.Client):
         return raw.types.InputBotInlineResult(
             id=self.id,
             type=self.type,

--- a/hydrogram/types/inline_mode/inline_query_result_video.py
+++ b/hydrogram/types/inline_mode/inline_query_result_video.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import enums, raw, types, utils
@@ -85,17 +85,17 @@ class InlineQueryResultVideo(InlineQueryResult):
         video_url: str,
         thumb_url: str,
         title: str,
-        id: Optional[str] = None,
+        id: str | None = None,
         mime_type: str = "video/mp4",
         video_width: int = 0,
         video_height: int = 0,
         video_duration: int = 0,
-        description: Optional[str] = None,
+        description: str | None = None,
         caption: str = "",
-        parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: Optional[list["types.MessageEntity"]] = None,
-        reply_markup: "types.InlineKeyboardMarkup" = None,
-        input_message_content: "types.InputMessageContent" = None,
+        parse_mode: enums.ParseMode | None = None,
+        caption_entities: list[types.MessageEntity] | None = None,
+        reply_markup: types.InlineKeyboardMarkup = None,
+        input_message_content: types.InputMessageContent = None,
     ):
         super().__init__("video", id, input_message_content, reply_markup)
 
@@ -111,7 +111,7 @@ class InlineQueryResultVideo(InlineQueryResult):
         self.caption_entities = caption_entities
         self.mime_type = mime_type
 
-    async def write(self, client: "hydrogram.Client"):
+    async def write(self, client: hydrogram.Client):
         video = raw.types.InputWebDocument(
             url=self.video_url,
             size=0,

--- a/hydrogram/types/inline_mode/inline_query_result_voice.py
+++ b/hydrogram/types/inline_mode/inline_query_result_voice.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import enums, raw, types, utils
@@ -67,13 +67,13 @@ class InlineQueryResultVoice(InlineQueryResult):
         self,
         voice_url: str,
         title: str,
-        id: Optional[str] = None,
+        id: str | None = None,
         voice_duration: int = 0,
         caption: str = "",
-        parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: Optional[list["types.MessageEntity"]] = None,
-        reply_markup: "types.InlineKeyboardMarkup" = None,
-        input_message_content: "types.InputMessageContent" = None,
+        parse_mode: enums.ParseMode | None = None,
+        caption_entities: list[types.MessageEntity] | None = None,
+        reply_markup: types.InlineKeyboardMarkup = None,
+        input_message_content: types.InputMessageContent = None,
     ):
         super().__init__("voice", id, input_message_content, reply_markup)
 
@@ -84,7 +84,7 @@ class InlineQueryResultVoice(InlineQueryResult):
         self.parse_mode = parse_mode
         self.caption_entities = caption_entities
 
-    async def write(self, client: "hydrogram.Client"):
+    async def write(self, client: hydrogram.Client):
         audio = raw.types.InputWebDocument(
             url=self.voice_url,
             size=0,

--- a/hydrogram/types/input_media/input_media.py
+++ b/hydrogram/types/input_media/input_media.py
@@ -17,10 +17,14 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import BinaryIO, Optional, Union
+from __future__ import annotations
 
-from hydrogram.types.messages_and_media import MessageEntity
+from typing import TYPE_CHECKING, BinaryIO
+
 from hydrogram.types.object import Object
+
+if TYPE_CHECKING:
+    from hydrogram.types.messages_and_media import MessageEntity
 
 
 class InputMedia(Object):
@@ -37,10 +41,10 @@ class InputMedia(Object):
 
     def __init__(
         self,
-        media: Union[str, BinaryIO],
+        media: str | BinaryIO,
         caption: str = "",
-        parse_mode: Optional[str] = None,
-        caption_entities: Optional[list[MessageEntity]] = None,
+        parse_mode: str | None = None,
+        caption_entities: list[MessageEntity] | None = None,
     ):
         super().__init__()
 

--- a/hydrogram/types/input_media/input_media_animation.py
+++ b/hydrogram/types/input_media/input_media_animation.py
@@ -17,12 +17,15 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import BinaryIO, Optional, Union
+from __future__ import annotations
 
-from hydrogram import enums
-from hydrogram.types.messages_and_media import MessageEntity
+from typing import TYPE_CHECKING, BinaryIO
 
 from .input_media import InputMedia
+
+if TYPE_CHECKING:
+    from hydrogram import enums
+    from hydrogram.types.messages_and_media import MessageEntity
 
 
 class InputMediaAnimation(InputMedia):
@@ -68,15 +71,15 @@ class InputMediaAnimation(InputMedia):
 
     def __init__(
         self,
-        media: Union[str, BinaryIO],
-        thumb: Optional[str] = None,
+        media: str | BinaryIO,
+        thumb: str | None = None,
         caption: str = "",
-        parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: Optional[list[MessageEntity]] = None,
+        parse_mode: enums.ParseMode | None = None,
+        caption_entities: list[MessageEntity] | None = None,
         width: int = 0,
         height: int = 0,
         duration: int = 0,
-        has_spoiler: Optional[bool] = None,
+        has_spoiler: bool | None = None,
     ):
         super().__init__(media, caption, parse_mode, caption_entities)
 

--- a/hydrogram/types/input_media/input_media_audio.py
+++ b/hydrogram/types/input_media/input_media_audio.py
@@ -17,12 +17,15 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import BinaryIO, Optional, Union
+from __future__ import annotations
 
-from hydrogram import enums
-from hydrogram.types.messages_and_media import MessageEntity
+from typing import TYPE_CHECKING, BinaryIO
 
 from .input_media import InputMedia
+
+if TYPE_CHECKING:
+    from hydrogram import enums
+    from hydrogram.types.messages_and_media import MessageEntity
 
 
 class InputMediaAudio(InputMedia):
@@ -67,11 +70,11 @@ class InputMediaAudio(InputMedia):
 
     def __init__(
         self,
-        media: Union[str, BinaryIO],
-        thumb: Optional[str] = None,
+        media: str | BinaryIO,
+        thumb: str | None = None,
         caption: str = "",
-        parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: Optional[list[MessageEntity]] = None,
+        parse_mode: enums.ParseMode | None = None,
+        caption_entities: list[MessageEntity] | None = None,
         duration: int = 0,
         performer: str = "",
         title: str = "",

--- a/hydrogram/types/input_media/input_media_document.py
+++ b/hydrogram/types/input_media/input_media_document.py
@@ -17,12 +17,15 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import BinaryIO, Optional, Union
+from __future__ import annotations
 
-from hydrogram import enums
-from hydrogram.types.messages_and_media import MessageEntity
+from typing import TYPE_CHECKING, BinaryIO
 
 from .input_media import InputMedia
+
+if TYPE_CHECKING:
+    from hydrogram import enums
+    from hydrogram.types.messages_and_media import MessageEntity
 
 
 class InputMediaDocument(InputMedia):
@@ -56,11 +59,11 @@ class InputMediaDocument(InputMedia):
 
     def __init__(
         self,
-        media: Union[str, BinaryIO],
-        thumb: Optional[str] = None,
+        media: str | BinaryIO,
+        thumb: str | None = None,
         caption: str = "",
-        parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: Optional[list[MessageEntity]] = None,
+        parse_mode: enums.ParseMode | None = None,
+        caption_entities: list[MessageEntity] | None = None,
     ):
         super().__init__(media, caption, parse_mode, caption_entities)
 

--- a/hydrogram/types/input_media/input_media_photo.py
+++ b/hydrogram/types/input_media/input_media_photo.py
@@ -17,12 +17,15 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import BinaryIO, Optional, Union
+from __future__ import annotations
 
-from hydrogram import enums
-from hydrogram.types.messages_and_media import MessageEntity
+from typing import TYPE_CHECKING, BinaryIO
 
 from .input_media import InputMedia
+
+if TYPE_CHECKING:
+    from hydrogram import enums
+    from hydrogram.types.messages_and_media import MessageEntity
 
 
 class InputMediaPhoto(InputMedia):
@@ -54,11 +57,11 @@ class InputMediaPhoto(InputMedia):
 
     def __init__(
         self,
-        media: Union[str, BinaryIO],
+        media: str | BinaryIO,
         caption: str = "",
-        parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: Optional[list[MessageEntity]] = None,
-        has_spoiler: Optional[bool] = None,
+        parse_mode: enums.ParseMode | None = None,
+        caption_entities: list[MessageEntity] | None = None,
+        has_spoiler: bool | None = None,
     ):
         super().__init__(media, caption, parse_mode, caption_entities)
 

--- a/hydrogram/types/input_media/input_media_video.py
+++ b/hydrogram/types/input_media/input_media_video.py
@@ -17,12 +17,15 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import BinaryIO, Optional, Union
+from __future__ import annotations
 
-from hydrogram import enums
-from hydrogram.types.messages_and_media import MessageEntity
+from typing import TYPE_CHECKING, BinaryIO
 
 from .input_media import InputMedia
+
+if TYPE_CHECKING:
+    from hydrogram import enums
+    from hydrogram.types.messages_and_media import MessageEntity
 
 
 class InputMediaVideo(InputMedia):
@@ -72,16 +75,16 @@ class InputMediaVideo(InputMedia):
 
     def __init__(
         self,
-        media: Union[str, BinaryIO],
-        thumb: Optional[str] = None,
+        media: str | BinaryIO,
+        thumb: str | None = None,
         caption: str = "",
-        parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: Optional[list[MessageEntity]] = None,
+        parse_mode: enums.ParseMode | None = None,
+        caption_entities: list[MessageEntity] | None = None,
         width: int = 0,
         height: int = 0,
         duration: int = 0,
         supports_streaming: bool = True,
-        has_spoiler: Optional[bool] = None,
+        has_spoiler: bool | None = None,
     ):
         super().__init__(media, caption, parse_mode, caption_entities)
 

--- a/hydrogram/types/input_message_content/input_message_content.py
+++ b/hydrogram/types/input_message_content/input_message_content.py
@@ -17,8 +17,12 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-import hydrogram
+from typing import TYPE_CHECKING
+
 from hydrogram.types.object import Object
+
+if TYPE_CHECKING:
+    import hydrogram
 
 """- :obj:`~hydrogram.types.InputLocationMessageContent`
     - :obj:`~hydrogram.types.InputVenueMessageContent`

--- a/hydrogram/types/input_message_content/input_text_message_content.py
+++ b/hydrogram/types/input_message_content/input_text_message_content.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import enums, raw, types, utils
@@ -46,9 +46,9 @@ class InputTextMessageContent(InputMessageContent):
     def __init__(
         self,
         message_text: str,
-        parse_mode: Optional["enums.ParseMode"] = None,
-        entities: Optional[list["types.MessageEntity"]] = None,
-        disable_web_page_preview: Optional[bool] = None,
+        parse_mode: enums.ParseMode | None = None,
+        entities: list[types.MessageEntity] | None = None,
+        disable_web_page_preview: bool | None = None,
     ):
         super().__init__()
 
@@ -57,7 +57,7 @@ class InputTextMessageContent(InputMessageContent):
         self.entities = entities
         self.disable_web_page_preview = disable_web_page_preview
 
-    async def write(self, client: "hydrogram.Client", reply_markup):
+    async def write(self, client: hydrogram.Client, reply_markup):
         message, entities = (
             await utils.parse_text_entities(
                 client, self.message_text, self.parse_mode, self.entities

--- a/hydrogram/types/messages_and_media/animation.py
+++ b/hydrogram/types/messages_and_media/animation.py
@@ -17,13 +17,17 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from datetime import datetime
-from typing import Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import hydrogram
 from hydrogram import raw, types, utils
 from hydrogram.file_id import FileId, FileType, FileUniqueId, FileUniqueType
 from hydrogram.types.object import Object
+
+if TYPE_CHECKING:
+    from datetime import datetime
 
 
 class Animation(Object):
@@ -65,17 +69,17 @@ class Animation(Object):
     def __init__(
         self,
         *,
-        client: "hydrogram.Client" = None,
+        client: hydrogram.Client = None,
         file_id: str,
         file_unique_id: str,
         width: int,
         height: int,
         duration: int,
-        file_name: Optional[str] = None,
-        mime_type: Optional[str] = None,
-        file_size: Optional[int] = None,
-        date: Optional[datetime] = None,
-        thumbs: Optional[list["types.Thumbnail"]] = None,
+        file_name: str | None = None,
+        mime_type: str | None = None,
+        file_size: int | None = None,
+        date: datetime | None = None,
+        thumbs: list[types.Thumbnail] | None = None,
     ):
         super().__init__(client)
 
@@ -93,10 +97,10 @@ class Animation(Object):
     @staticmethod
     def _parse(
         client,
-        animation: "raw.types.Document",
-        video_attributes: "raw.types.DocumentAttributeVideo",
+        animation: raw.types.Document,
+        video_attributes: raw.types.DocumentAttributeVideo,
         file_name: str,
-    ) -> "Animation":
+    ) -> Animation:
         return Animation(
             file_id=FileId(
                 file_type=FileType.ANIMATION,

--- a/hydrogram/types/messages_and_media/audio.py
+++ b/hydrogram/types/messages_and_media/audio.py
@@ -17,13 +17,17 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from datetime import datetime
-from typing import Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import hydrogram
 from hydrogram import raw, types, utils
 from hydrogram.file_id import FileId, FileType, FileUniqueId, FileUniqueType
 from hydrogram.types.object import Object
+
+if TYPE_CHECKING:
+    from datetime import datetime
 
 
 class Audio(Object):
@@ -65,17 +69,17 @@ class Audio(Object):
     def __init__(
         self,
         *,
-        client: "hydrogram.Client" = None,
+        client: hydrogram.Client = None,
         file_id: str,
         file_unique_id: str,
         duration: int,
-        performer: Optional[str] = None,
-        title: Optional[str] = None,
-        file_name: Optional[str] = None,
-        mime_type: Optional[str] = None,
-        file_size: Optional[int] = None,
-        date: Optional[datetime] = None,
-        thumbs: Optional[list["types.Thumbnail"]] = None,
+        performer: str | None = None,
+        title: str | None = None,
+        file_name: str | None = None,
+        mime_type: str | None = None,
+        file_size: int | None = None,
+        date: datetime | None = None,
+        thumbs: list[types.Thumbnail] | None = None,
     ):
         super().__init__(client)
 
@@ -93,10 +97,10 @@ class Audio(Object):
     @staticmethod
     def _parse(
         client,
-        audio: "raw.types.Document",
-        audio_attributes: "raw.types.DocumentAttributeAudio",
+        audio: raw.types.Document,
+        audio_attributes: raw.types.DocumentAttributeAudio,
         file_name: str,
-    ) -> "Audio":
+    ) -> Audio:
         return Audio(
             file_id=FileId(
                 file_type=FileType.AUDIO,

--- a/hydrogram/types/messages_and_media/contact.py
+++ b/hydrogram/types/messages_and_media/contact.py
@@ -17,11 +17,15 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
+from __future__ import annotations
 
-import hydrogram
-from hydrogram import raw
+from typing import TYPE_CHECKING
+
 from hydrogram.types.object import Object
+
+if TYPE_CHECKING:
+    import hydrogram
+    from hydrogram import raw
 
 
 class Contact(Object):
@@ -47,12 +51,12 @@ class Contact(Object):
     def __init__(
         self,
         *,
-        client: "hydrogram.Client" = None,
+        client: hydrogram.Client = None,
         phone_number: str,
         first_name: str,
-        last_name: Optional[str] = None,
-        user_id: Optional[int] = None,
-        vcard: Optional[str] = None,
+        last_name: str | None = None,
+        user_id: int | None = None,
+        vcard: str | None = None,
     ):
         super().__init__(client)
 
@@ -63,7 +67,7 @@ class Contact(Object):
         self.vcard = vcard
 
     @staticmethod
-    def _parse(client: "hydrogram.Client", contact: "raw.types.MessageMediaContact") -> "Contact":
+    def _parse(client: hydrogram.Client, contact: raw.types.MessageMediaContact) -> Contact:
         return Contact(
             phone_number=contact.phone_number,
             first_name=contact.first_name,

--- a/hydrogram/types/messages_and_media/dice.py
+++ b/hydrogram/types/messages_and_media/dice.py
@@ -17,9 +17,13 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-import hydrogram
-from hydrogram import raw
+from typing import TYPE_CHECKING
+
 from hydrogram.types.object import Object
+
+if TYPE_CHECKING:
+    import hydrogram
+    from hydrogram import raw
 
 
 class Dice(Object):

--- a/hydrogram/types/messages_and_media/document.py
+++ b/hydrogram/types/messages_and_media/document.py
@@ -17,13 +17,17 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from datetime import datetime
-from typing import Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import hydrogram
 from hydrogram import raw, types, utils
 from hydrogram.file_id import FileId, FileType, FileUniqueId, FileUniqueType
 from hydrogram.types.object import Object
+
+if TYPE_CHECKING:
+    from datetime import datetime
 
 
 class Document(Object):
@@ -56,14 +60,14 @@ class Document(Object):
     def __init__(
         self,
         *,
-        client: "hydrogram.Client" = None,
+        client: hydrogram.Client = None,
         file_id: str,
         file_unique_id: str,
-        file_name: Optional[str] = None,
-        mime_type: Optional[str] = None,
-        file_size: Optional[int] = None,
-        date: Optional[datetime] = None,
-        thumbs: Optional[list["types.Thumbnail"]] = None,
+        file_name: str | None = None,
+        mime_type: str | None = None,
+        file_size: int | None = None,
+        date: datetime | None = None,
+        thumbs: list[types.Thumbnail] | None = None,
     ):
         super().__init__(client)
 
@@ -76,7 +80,7 @@ class Document(Object):
         self.thumbs = thumbs
 
     @staticmethod
-    def _parse(client, document: "raw.types.Document", file_name: str) -> "Document":
+    def _parse(client, document: raw.types.Document, file_name: str) -> Document:
         return Document(
             file_id=FileId(
                 file_type=FileType.DOCUMENT,

--- a/hydrogram/types/messages_and_media/game.py
+++ b/hydrogram/types/messages_and_media/game.py
@@ -69,7 +69,7 @@ class Game(Object):
 
     @staticmethod
     def _parse(client, message: "raw.types.Message") -> "Game":
-        game: "raw.types.Game" = message.media.game
+        game: raw.types.Game = message.media.game
         animation = None
 
         if game.document:

--- a/hydrogram/types/messages_and_media/message.py
+++ b/hydrogram/types/messages_and_media/message.py
@@ -17,11 +17,11 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import logging
-from datetime import datetime
 from functools import partial
-from re import Match
-from typing import BinaryIO, Callable, Optional, Union
+from typing import TYPE_CHECKING, BinaryIO, Callable
 
 import hydrogram
 from hydrogram import enums, filters, raw, types, utils
@@ -31,6 +31,10 @@ from hydrogram.parser import utils as parser_utils
 from hydrogram.types.object import Object
 from hydrogram.types.pyromod import ListenerTypes
 from hydrogram.types.update import Update
+
+if TYPE_CHECKING:
+    from datetime import datetime
+    from re import Match
 
 log = logging.getLogger(__name__)
 
@@ -340,90 +344,88 @@ class Message(Object, Update):
     def __init__(
         self,
         *,
-        client: "hydrogram.Client" = None,
+        client: hydrogram.Client = None,
         id: int,
-        message_thread_id: Optional[int] = None,
-        from_user: "types.User" = None,
-        sender_chat: "types.Chat" = None,
-        date: Optional[datetime] = None,
-        chat: "types.Chat" = None,
-        topics: "types.ForumTopic" = None,
-        forward_from: "types.User" = None,
-        forward_sender_name: Optional[str] = None,
-        forward_from_chat: "types.Chat" = None,
-        forward_from_message_id: Optional[int] = None,
-        forward_signature: Optional[str] = None,
-        forward_date: Optional[datetime] = None,
-        is_topic_message: Optional[bool] = None,
-        reply_to_message_id: Optional[int] = None,
-        reply_to_top_message_id: Optional[int] = None,
-        reply_to_message: "Message" = None,
-        mentioned: Optional[bool] = None,
-        empty: Optional[bool] = None,
-        service: "enums.MessageServiceType" = None,
-        scheduled: Optional[bool] = None,
-        from_scheduled: Optional[bool] = None,
-        media: "enums.MessageMediaType" = None,
-        edit_date: Optional[datetime] = None,
-        media_group_id: Optional[str] = None,
-        author_signature: Optional[str] = None,
-        has_protected_content: Optional[bool] = None,
-        has_media_spoiler: Optional[bool] = None,
+        message_thread_id: int | None = None,
+        from_user: types.User = None,
+        sender_chat: types.Chat = None,
+        date: datetime | None = None,
+        chat: types.Chat = None,
+        topics: types.ForumTopic = None,
+        forward_from: types.User = None,
+        forward_sender_name: str | None = None,
+        forward_from_chat: types.Chat = None,
+        forward_from_message_id: int | None = None,
+        forward_signature: str | None = None,
+        forward_date: datetime | None = None,
+        is_topic_message: bool | None = None,
+        reply_to_message_id: int | None = None,
+        reply_to_top_message_id: int | None = None,
+        reply_to_message: Message = None,
+        mentioned: bool | None = None,
+        empty: bool | None = None,
+        service: enums.MessageServiceType = None,
+        scheduled: bool | None = None,
+        from_scheduled: bool | None = None,
+        media: enums.MessageMediaType = None,
+        edit_date: datetime | None = None,
+        media_group_id: str | None = None,
+        author_signature: str | None = None,
+        has_protected_content: bool | None = None,
+        has_media_spoiler: bool | None = None,
         text: Str = None,
-        entities: Optional[list["types.MessageEntity"]] = None,
-        caption_entities: Optional[list["types.MessageEntity"]] = None,
-        audio: "types.Audio" = None,
-        document: "types.Document" = None,
-        photo: "types.Photo" = None,
-        sticker: "types.Sticker" = None,
-        animation: "types.Animation" = None,
-        game: "types.Game" = None,
-        video: "types.Video" = None,
-        voice: "types.Voice" = None,
-        video_note: "types.VideoNote" = None,
+        entities: list[types.MessageEntity] | None = None,
+        caption_entities: list[types.MessageEntity] | None = None,
+        audio: types.Audio = None,
+        document: types.Document = None,
+        photo: types.Photo = None,
+        sticker: types.Sticker = None,
+        animation: types.Animation = None,
+        game: types.Game = None,
+        video: types.Video = None,
+        voice: types.Voice = None,
+        video_note: types.VideoNote = None,
         caption: Str = None,
-        contact: "types.Contact" = None,
-        location: "types.Location" = None,
-        venue: "types.Venue" = None,
-        web_page: "types.WebPage" = None,
-        poll: "types.Poll" = None,
-        dice: "types.Dice" = None,
-        new_chat_members: Optional[list["types.User"]] = None,
-        left_chat_member: "types.User" = None,
-        new_chat_title: Optional[str] = None,
-        new_chat_photo: "types.Photo" = None,
-        delete_chat_photo: Optional[bool] = None,
-        group_chat_created: Optional[bool] = None,
-        supergroup_chat_created: Optional[bool] = None,
-        channel_chat_created: Optional[bool] = None,
-        migrate_to_chat_id: Optional[int] = None,
-        migrate_from_chat_id: Optional[int] = None,
-        pinned_message: "Message" = None,
-        game_high_score: Optional[int] = None,
-        views: Optional[int] = None,
-        forwards: Optional[int] = None,
-        via_bot: "types.User" = None,
-        outgoing: Optional[bool] = None,
-        matches: Optional[list[Match]] = None,
-        command: Optional[list[str]] = None,
-        forum_topic_created: "types.ForumTopicCreated" = None,
-        forum_topic_closed: "types.ForumTopicClosed" = None,
-        forum_topic_reopened: "types.ForumTopicReopened" = None,
-        forum_topic_edited: "types.ForumTopicEdited" = None,
-        general_topic_hidden: "types.GeneralTopicHidden" = None,
-        general_topic_unhidden: "types.GeneralTopicUnhidden" = None,
-        video_chat_scheduled: "types.VideoChatScheduled" = None,
-        video_chat_started: "types.VideoChatStarted" = None,
-        video_chat_ended: "types.VideoChatEnded" = None,
-        video_chat_members_invited: "types.VideoChatMembersInvited" = None,
-        web_app_data: "types.WebAppData" = None,
-        reply_markup: Union[
-            "types.InlineKeyboardMarkup",
-            "types.ReplyKeyboardMarkup",
-            "types.ReplyKeyboardRemove",
-            "types.ForceReply",
-        ] = None,
-        reactions: Optional[list["types.Reaction"]] = None,
+        contact: types.Contact = None,
+        location: types.Location = None,
+        venue: types.Venue = None,
+        web_page: types.WebPage = None,
+        poll: types.Poll = None,
+        dice: types.Dice = None,
+        new_chat_members: list[types.User] | None = None,
+        left_chat_member: types.User = None,
+        new_chat_title: str | None = None,
+        new_chat_photo: types.Photo = None,
+        delete_chat_photo: bool | None = None,
+        group_chat_created: bool | None = None,
+        supergroup_chat_created: bool | None = None,
+        channel_chat_created: bool | None = None,
+        migrate_to_chat_id: int | None = None,
+        migrate_from_chat_id: int | None = None,
+        pinned_message: Message = None,
+        game_high_score: int | None = None,
+        views: int | None = None,
+        forwards: int | None = None,
+        via_bot: types.User = None,
+        outgoing: bool | None = None,
+        matches: list[Match] | None = None,
+        command: list[str] | None = None,
+        forum_topic_created: types.ForumTopicCreated = None,
+        forum_topic_closed: types.ForumTopicClosed = None,
+        forum_topic_reopened: types.ForumTopicReopened = None,
+        forum_topic_edited: types.ForumTopicEdited = None,
+        general_topic_hidden: types.GeneralTopicHidden = None,
+        general_topic_unhidden: types.GeneralTopicUnhidden = None,
+        video_chat_scheduled: types.VideoChatScheduled = None,
+        video_chat_started: types.VideoChatStarted = None,
+        video_chat_ended: types.VideoChatEnded = None,
+        video_chat_members_invited: types.VideoChatMembersInvited = None,
+        web_app_data: types.WebAppData = None,
+        reply_markup: types.InlineKeyboardMarkup
+        | types.ReplyKeyboardMarkup
+        | types.ReplyKeyboardRemove
+        | types.ForceReply = None,
+        reactions: list[types.Reaction] | None = None,
     ):
         super().__init__(client)
 
@@ -508,11 +510,11 @@ class Message(Object, Update):
 
     async def wait_for_click(
         self,
-        from_user_id: Optional[Union[int, str, list[Union[int, str]]]] = None,
-        timeout: Optional[int] = None,
+        from_user_id: int | str | list[int | str] | None = None,
+        timeout: int | None = None,
         filters=None,
-        alert: Union[str, bool] = True,
-    ) -> "types.CallbackQuery":
+        alert: str | bool = True,
+    ) -> types.CallbackQuery:
         """
         Waits for a callback query to be clicked on the message.
 
@@ -548,11 +550,11 @@ class Message(Object, Update):
     @staticmethod
     async def _parse(
         *,
-        client: "hydrogram.Client",
+        client: hydrogram.Client,
         message: raw.base.Message,
         users: dict,
         chats: dict,
-        topics: Optional[dict] = None,
+        topics: dict | None = None,
         is_scheduled: bool = False,
         replies: int = 1,
     ):
@@ -1034,13 +1036,13 @@ class Message(Object, Update):
 
     def listen(
         self,
-        filters: Optional["filters.Filter"] = None,
+        filters: filters.Filter | None = None,
         listener_type: ListenerTypes = ListenerTypes.MESSAGE,
-        timeout: Optional[int] = None,
+        timeout: int | None = None,
         unallowed_click_alert: bool = True,
-        user_id: Optional[Union[int, str, list[Union[int, str]]]] = None,
-        message_id: Optional[Union[int, list[int]]] = None,
-        inline_message_id: Optional[Union[str, list[str]]] = None,
+        user_id: int | str | list[int | str] | None = None,
+        message_id: int | list[int] | None = None,
+        inline_message_id: str | list[str] | None = None,
     ):
         """
         Bound method *listen* of :obj:`~hydrogram.types.Chat`.
@@ -1095,13 +1097,13 @@ class Message(Object, Update):
     def ask(
         self,
         text: str,
-        filters: Optional["filters.Filter"] = None,
+        filters: filters.Filter | None = None,
         listener_type: ListenerTypes = ListenerTypes.MESSAGE,
-        timeout: Optional[int] = None,
+        timeout: int | None = None,
         unallowed_click_alert: bool = True,
-        user_id: Optional[Union[int, str, list[Union[int, str]]]] = None,
-        message_id: Optional[Union[int, list[int]]] = None,
-        inline_message_id: Optional[Union[str, list[str]]] = None,
+        user_id: int | str | list[int | str] | None = None,
+        message_id: int | list[int] | None = None,
+        inline_message_id: str | list[str] | None = None,
         *args,
         **kwargs,
     ):
@@ -1171,9 +1173,9 @@ class Message(Object, Update):
     def stop_listening(
         self,
         listener_type: ListenerTypes = ListenerTypes.MESSAGE,
-        user_id: Optional[Union[int, str, list[Union[int, str]]]] = None,
-        message_id: Optional[Union[int, list[int]]] = None,
-        inline_message_id: Optional[Union[str, list[str]]] = None,
+        user_id: int | str | list[int | str] | None = None,
+        message_id: int | list[int] | None = None,
+        inline_message_id: str | list[str] | None = None,
     ):
         """
         Bound method *stop_listening* of :obj:`~hydrogram.types.Chat`.
@@ -1223,7 +1225,7 @@ class Message(Object, Update):
             return f"https://t.me/{self.chat.username}/{self.id}"
         return f"https://t.me/c/{utils.get_channel_id(self.chat.id)}/{self.id}"
 
-    async def get_media_group(self) -> list["types.Message"]:
+    async def get_media_group(self) -> list[types.Message]:
         """Bound method *get_media_group* of :obj:`~hydrogram.types.Message`.
 
         Use as a shortcut for:
@@ -1249,16 +1251,16 @@ class Message(Object, Update):
     async def reply_text(
         self,
         text: str,
-        quote: Optional[bool] = None,
-        parse_mode: Optional["enums.ParseMode"] = None,
-        entities: Optional[list["types.MessageEntity"]] = None,
-        disable_web_page_preview: Optional[bool] = None,
-        disable_notification: Optional[bool] = None,
-        reply_to_message_id: Optional[int] = None,
-        schedule_date: Optional[datetime] = None,
-        protect_content: Optional[bool] = None,
+        quote: bool | None = None,
+        parse_mode: enums.ParseMode | None = None,
+        entities: list[types.MessageEntity] | None = None,
+        disable_web_page_preview: bool | None = None,
+        disable_notification: bool | None = None,
+        reply_to_message_id: int | None = None,
+        schedule_date: datetime | None = None,
+        protect_content: bool | None = None,
         reply_markup=None,
-    ) -> "Message":
+    ) -> Message:
         """Bound method *reply_text* of :obj:`~hydrogram.types.Message`.
 
         An alias exists as *reply*.
@@ -1345,27 +1347,25 @@ class Message(Object, Update):
 
     async def reply_animation(
         self,
-        animation: Union[str, BinaryIO],
-        quote: Optional[bool] = None,
+        animation: str | BinaryIO,
+        quote: bool | None = None,
         caption: str = "",
-        parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: Optional[list["types.MessageEntity"]] = None,
-        has_spoiler: Optional[bool] = None,
+        parse_mode: enums.ParseMode | None = None,
+        caption_entities: list[types.MessageEntity] | None = None,
+        has_spoiler: bool | None = None,
         duration: int = 0,
         width: int = 0,
         height: int = 0,
-        thumb: Optional[str] = None,
-        disable_notification: Optional[bool] = None,
-        reply_markup: Union[
-            "types.InlineKeyboardMarkup",
-            "types.ReplyKeyboardMarkup",
-            "types.ReplyKeyboardRemove",
-            "types.ForceReply",
-        ] = None,
-        reply_to_message_id: Optional[int] = None,
-        progress: Optional[Callable] = None,
+        thumb: str | None = None,
+        disable_notification: bool | None = None,
+        reply_markup: types.InlineKeyboardMarkup
+        | types.ReplyKeyboardMarkup
+        | types.ReplyKeyboardRemove
+        | types.ForceReply = None,
+        reply_to_message_id: int | None = None,
+        progress: Callable | None = None,
         progress_args: tuple = (),
-    ) -> "Message":
+    ) -> Message:
         """Bound method *reply_animation* :obj:`~hydrogram.types.Message`.
 
         Use as a shortcut for:
@@ -1491,26 +1491,24 @@ class Message(Object, Update):
 
     async def reply_audio(
         self,
-        audio: Union[str, BinaryIO],
-        quote: Optional[bool] = None,
+        audio: str | BinaryIO,
+        quote: bool | None = None,
         caption: str = "",
-        parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: Optional[list["types.MessageEntity"]] = None,
+        parse_mode: enums.ParseMode | None = None,
+        caption_entities: list[types.MessageEntity] | None = None,
         duration: int = 0,
-        performer: Optional[str] = None,
-        title: Optional[str] = None,
-        thumb: Optional[str] = None,
-        disable_notification: Optional[bool] = None,
-        reply_to_message_id: Optional[int] = None,
-        reply_markup: Union[
-            "types.InlineKeyboardMarkup",
-            "types.ReplyKeyboardMarkup",
-            "types.ReplyKeyboardRemove",
-            "types.ForceReply",
-        ] = None,
-        progress: Optional[Callable] = None,
+        performer: str | None = None,
+        title: str | None = None,
+        thumb: str | None = None,
+        disable_notification: bool | None = None,
+        reply_to_message_id: int | None = None,
+        reply_markup: types.InlineKeyboardMarkup
+        | types.ReplyKeyboardMarkup
+        | types.ReplyKeyboardRemove
+        | types.ForceReply = None,
+        progress: Callable | None = None,
         progress_args: tuple = (),
-    ) -> "Message":
+    ) -> Message:
         """Bound method *reply_audio* of :obj:`~hydrogram.types.Message`.
 
         Use as a shortcut for:
@@ -1631,19 +1629,17 @@ class Message(Object, Update):
     async def reply_cached_media(
         self,
         file_id: str,
-        quote: Optional[bool] = None,
+        quote: bool | None = None,
         caption: str = "",
-        parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: Optional[list["types.MessageEntity"]] = None,
-        disable_notification: Optional[bool] = None,
-        reply_to_message_id: Optional[int] = None,
-        reply_markup: Union[
-            "types.InlineKeyboardMarkup",
-            "types.ReplyKeyboardMarkup",
-            "types.ReplyKeyboardRemove",
-            "types.ForceReply",
-        ] = None,
-    ) -> "Message":
+        parse_mode: enums.ParseMode | None = None,
+        caption_entities: list[types.MessageEntity] | None = None,
+        disable_notification: bool | None = None,
+        reply_to_message_id: int | None = None,
+        reply_markup: types.InlineKeyboardMarkup
+        | types.ReplyKeyboardMarkup
+        | types.ReplyKeyboardRemove
+        | types.ForceReply = None,
+    ) -> Message:
         """Bound method *reply_cached_media* of :obj:`~hydrogram.types.Message`.
 
         Use as a shortcut for:
@@ -1714,7 +1710,7 @@ class Message(Object, Update):
             reply_markup=reply_markup,
         )
 
-    async def reply_chat_action(self, action: "enums.ChatAction") -> bool:
+    async def reply_chat_action(self, action: enums.ChatAction) -> bool:
         """Bound method *reply_chat_action* of :obj:`~hydrogram.types.Message`.
 
         Use as a shortcut for:
@@ -1755,18 +1751,16 @@ class Message(Object, Update):
         self,
         phone_number: str,
         first_name: str,
-        quote: Optional[bool] = None,
+        quote: bool | None = None,
         last_name: str = "",
         vcard: str = "",
-        disable_notification: Optional[bool] = None,
-        reply_to_message_id: Optional[int] = None,
-        reply_markup: Union[
-            "types.InlineKeyboardMarkup",
-            "types.ReplyKeyboardMarkup",
-            "types.ReplyKeyboardRemove",
-            "types.ForceReply",
-        ] = None,
-    ) -> "Message":
+        disable_notification: bool | None = None,
+        reply_to_message_id: int | None = None,
+        reply_markup: types.InlineKeyboardMarkup
+        | types.ReplyKeyboardMarkup
+        | types.ReplyKeyboardRemove
+        | types.ForceReply = None,
+    ) -> Message:
         """Bound method *reply_contact* of :obj:`~hydrogram.types.Message`.
 
         Use as a shortcut for:
@@ -1840,26 +1834,24 @@ class Message(Object, Update):
 
     async def reply_document(
         self,
-        document: Union[str, BinaryIO],
-        quote: Optional[bool] = None,
-        thumb: Optional[str] = None,
+        document: str | BinaryIO,
+        quote: bool | None = None,
+        thumb: str | None = None,
         caption: str = "",
-        parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: Optional[list["types.MessageEntity"]] = None,
-        file_name: Optional[str] = None,
-        force_document: Optional[bool] = None,
-        disable_notification: Optional[bool] = None,
-        reply_to_message_id: Optional[int] = None,
-        schedule_date: Optional[datetime] = None,
-        reply_markup: Union[
-            "types.InlineKeyboardMarkup",
-            "types.ReplyKeyboardMarkup",
-            "types.ReplyKeyboardRemove",
-            "types.ForceReply",
-        ] = None,
-        progress: Optional[Callable] = None,
+        parse_mode: enums.ParseMode | None = None,
+        caption_entities: list[types.MessageEntity] | None = None,
+        file_name: str | None = None,
+        force_document: bool | None = None,
+        disable_notification: bool | None = None,
+        reply_to_message_id: int | None = None,
+        schedule_date: datetime | None = None,
+        reply_markup: types.InlineKeyboardMarkup
+        | types.ReplyKeyboardMarkup
+        | types.ReplyKeyboardRemove
+        | types.ForceReply = None,
+        progress: Callable | None = None,
         progress_args: tuple = (),
-    ) -> "Message":
+    ) -> Message:
         """Bound method *reply_document* of :obj:`~hydrogram.types.Message`.
 
         Use as a shortcut for:
@@ -1983,16 +1975,14 @@ class Message(Object, Update):
     async def reply_game(
         self,
         game_short_name: str,
-        quote: Optional[bool] = None,
-        disable_notification: Optional[bool] = None,
-        reply_to_message_id: Optional[int] = None,
-        reply_markup: Union[
-            "types.InlineKeyboardMarkup",
-            "types.ReplyKeyboardMarkup",
-            "types.ReplyKeyboardRemove",
-            "types.ForceReply",
-        ] = None,
-    ) -> "Message":
+        quote: bool | None = None,
+        disable_notification: bool | None = None,
+        reply_to_message_id: int | None = None,
+        reply_markup: types.InlineKeyboardMarkup
+        | types.ReplyKeyboardMarkup
+        | types.ReplyKeyboardRemove
+        | types.ForceReply = None,
+    ) -> Message:
         """Bound method *reply_game* of :obj:`~hydrogram.types.Message`.
 
         Use as a shortcut for:
@@ -2055,10 +2045,10 @@ class Message(Object, Update):
         self,
         query_id: int,
         result_id: str,
-        quote: Optional[bool] = None,
-        disable_notification: Optional[bool] = None,
-        reply_to_message_id: Optional[int] = None,
-    ) -> "Message":
+        quote: bool | None = None,
+        disable_notification: bool | None = None,
+        reply_to_message_id: int | None = None,
+    ) -> Message:
         """Bound method *reply_inline_bot_result* of :obj:`~hydrogram.types.Message`.
 
         Use as a shortcut for:
@@ -2121,16 +2111,14 @@ class Message(Object, Update):
         self,
         latitude: float,
         longitude: float,
-        quote: Optional[bool] = None,
-        disable_notification: Optional[bool] = None,
-        reply_to_message_id: Optional[int] = None,
-        reply_markup: Union[
-            "types.InlineKeyboardMarkup",
-            "types.ReplyKeyboardMarkup",
-            "types.ReplyKeyboardRemove",
-            "types.ForceReply",
-        ] = None,
-    ) -> "Message":
+        quote: bool | None = None,
+        disable_notification: bool | None = None,
+        reply_to_message_id: int | None = None,
+        reply_markup: types.InlineKeyboardMarkup
+        | types.ReplyKeyboardMarkup
+        | types.ReplyKeyboardRemove
+        | types.ForceReply = None,
+    ) -> Message:
         """Bound method *reply_location* of :obj:`~hydrogram.types.Message`.
 
         Use as a shortcut for:
@@ -2196,11 +2184,11 @@ class Message(Object, Update):
 
     async def reply_media_group(
         self,
-        media: list[Union["types.InputMediaPhoto", "types.InputMediaVideo"]],
-        quote: Optional[bool] = None,
-        disable_notification: Optional[bool] = None,
-        reply_to_message_id: Optional[int] = None,
-    ) -> list["types.Message"]:
+        media: list[types.InputMediaPhoto | types.InputMediaVideo],
+        quote: bool | None = None,
+        disable_notification: bool | None = None,
+        reply_to_message_id: int | None = None,
+    ) -> list[types.Message]:
         """Bound method *reply_media_group* of :obj:`~hydrogram.types.Message`.
 
         Use as a shortcut for:
@@ -2259,24 +2247,22 @@ class Message(Object, Update):
 
     async def reply_photo(
         self,
-        photo: Union[str, BinaryIO],
-        quote: Optional[bool] = None,
+        photo: str | BinaryIO,
+        quote: bool | None = None,
         caption: str = "",
-        parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: Optional[list["types.MessageEntity"]] = None,
-        has_spoiler: Optional[bool] = None,
-        ttl_seconds: Optional[int] = None,
-        disable_notification: Optional[bool] = None,
-        reply_to_message_id: Optional[int] = None,
-        reply_markup: Union[
-            "types.InlineKeyboardMarkup",
-            "types.ReplyKeyboardMarkup",
-            "types.ReplyKeyboardRemove",
-            "types.ForceReply",
-        ] = None,
-        progress: Optional[Callable] = None,
+        parse_mode: enums.ParseMode | None = None,
+        caption_entities: list[types.MessageEntity] | None = None,
+        has_spoiler: bool | None = None,
+        ttl_seconds: int | None = None,
+        disable_notification: bool | None = None,
+        reply_to_message_id: int | None = None,
+        reply_markup: types.InlineKeyboardMarkup
+        | types.ReplyKeyboardMarkup
+        | types.ReplyKeyboardRemove
+        | types.ForceReply = None,
+        progress: Callable | None = None,
         progress_args: tuple = (),
-    ) -> "Message":
+    ) -> Message:
         """Bound method *reply_photo* of :obj:`~hydrogram.types.Message`.
 
         Use as a shortcut for:
@@ -2390,27 +2376,25 @@ class Message(Object, Update):
         question: str,
         options: list[str],
         is_anonymous: bool = True,
-        type: "enums.PollType" = enums.PollType.REGULAR,
-        allows_multiple_answers: Optional[bool] = None,
-        correct_option_id: Optional[int] = None,
-        explanation: Optional[str] = None,
-        explanation_parse_mode: "enums.ParseMode" = None,
-        explanation_entities: Optional[list["types.MessageEntity"]] = None,
-        open_period: Optional[int] = None,
-        close_date: Optional[datetime] = None,
-        is_closed: Optional[bool] = None,
-        quote: Optional[bool] = None,
-        disable_notification: Optional[bool] = None,
-        protect_content: Optional[bool] = None,
-        reply_to_message_id: Optional[int] = None,
-        schedule_date: Optional[datetime] = None,
-        reply_markup: Union[
-            "types.InlineKeyboardMarkup",
-            "types.ReplyKeyboardMarkup",
-            "types.ReplyKeyboardRemove",
-            "types.ForceReply",
-        ] = None,
-    ) -> "Message":
+        type: enums.PollType = enums.PollType.REGULAR,
+        allows_multiple_answers: bool | None = None,
+        correct_option_id: int | None = None,
+        explanation: str | None = None,
+        explanation_parse_mode: enums.ParseMode = None,
+        explanation_entities: list[types.MessageEntity] | None = None,
+        open_period: int | None = None,
+        close_date: datetime | None = None,
+        is_closed: bool | None = None,
+        quote: bool | None = None,
+        disable_notification: bool | None = None,
+        protect_content: bool | None = None,
+        reply_to_message_id: int | None = None,
+        schedule_date: datetime | None = None,
+        reply_markup: types.InlineKeyboardMarkup
+        | types.ReplyKeyboardMarkup
+        | types.ReplyKeyboardRemove
+        | types.ForceReply = None,
+    ) -> Message:
         """Bound method *reply_poll* of :obj:`~hydrogram.types.Message`.
 
         Use as a shortcut for:
@@ -2534,19 +2518,17 @@ class Message(Object, Update):
 
     async def reply_sticker(
         self,
-        sticker: Union[str, BinaryIO],
-        quote: Optional[bool] = None,
-        disable_notification: Optional[bool] = None,
-        reply_to_message_id: Optional[int] = None,
-        reply_markup: Union[
-            "types.InlineKeyboardMarkup",
-            "types.ReplyKeyboardMarkup",
-            "types.ReplyKeyboardRemove",
-            "types.ForceReply",
-        ] = None,
-        progress: Optional[Callable] = None,
+        sticker: str | BinaryIO,
+        quote: bool | None = None,
+        disable_notification: bool | None = None,
+        reply_to_message_id: int | None = None,
+        reply_markup: types.InlineKeyboardMarkup
+        | types.ReplyKeyboardMarkup
+        | types.ReplyKeyboardRemove
+        | types.ForceReply = None,
+        progress: Callable | None = None,
         progress_args: tuple = (),
-    ) -> "Message":
+    ) -> Message:
         """Bound method *reply_sticker* of :obj:`~hydrogram.types.Message`.
 
         Use as a shortcut for:
@@ -2638,18 +2620,16 @@ class Message(Object, Update):
         longitude: float,
         title: str,
         address: str,
-        quote: Optional[bool] = None,
+        quote: bool | None = None,
         foursquare_id: str = "",
         foursquare_type: str = "",
-        disable_notification: Optional[bool] = None,
-        reply_to_message_id: Optional[int] = None,
-        reply_markup: Union[
-            "types.InlineKeyboardMarkup",
-            "types.ReplyKeyboardMarkup",
-            "types.ReplyKeyboardRemove",
-            "types.ForceReply",
-        ] = None,
-    ) -> "Message":
+        disable_notification: bool | None = None,
+        reply_to_message_id: int | None = None,
+        reply_markup: types.InlineKeyboardMarkup
+        | types.ReplyKeyboardMarkup
+        | types.ReplyKeyboardRemove
+        | types.ForceReply = None,
+    ) -> Message:
         """Bound method *reply_venue* of :obj:`~hydrogram.types.Message`.
 
         Use as a shortcut for:
@@ -2734,29 +2714,27 @@ class Message(Object, Update):
 
     async def reply_video(
         self,
-        video: Union[str, BinaryIO],
-        quote: Optional[bool] = None,
+        video: str | BinaryIO,
+        quote: bool | None = None,
         caption: str = "",
-        parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: Optional[list["types.MessageEntity"]] = None,
-        has_spoiler: Optional[bool] = None,
-        ttl_seconds: Optional[int] = None,
+        parse_mode: enums.ParseMode | None = None,
+        caption_entities: list[types.MessageEntity] | None = None,
+        has_spoiler: bool | None = None,
+        ttl_seconds: int | None = None,
         duration: int = 0,
         width: int = 0,
         height: int = 0,
-        thumb: Optional[str] = None,
+        thumb: str | None = None,
         supports_streaming: bool = True,
-        disable_notification: Optional[bool] = None,
-        reply_to_message_id: Optional[int] = None,
-        reply_markup: Union[
-            "types.InlineKeyboardMarkup",
-            "types.ReplyKeyboardMarkup",
-            "types.ReplyKeyboardRemove",
-            "types.ForceReply",
-        ] = None,
-        progress: Optional[Callable] = None,
+        disable_notification: bool | None = None,
+        reply_to_message_id: int | None = None,
+        reply_markup: types.InlineKeyboardMarkup
+        | types.ReplyKeyboardMarkup
+        | types.ReplyKeyboardRemove
+        | types.ForceReply = None,
+        progress: Callable | None = None,
         progress_args: tuple = (),
-    ) -> "Message":
+    ) -> Message:
         """Bound method *reply_video* of :obj:`~hydrogram.types.Message`.
 
         Use as a shortcut for:
@@ -2890,22 +2868,20 @@ class Message(Object, Update):
 
     async def reply_video_note(
         self,
-        video_note: Union[str, BinaryIO],
-        quote: Optional[bool] = None,
+        video_note: str | BinaryIO,
+        quote: bool | None = None,
         duration: int = 0,
         length: int = 1,
-        thumb: Optional[str] = None,
-        disable_notification: Optional[bool] = None,
-        reply_to_message_id: Optional[int] = None,
-        reply_markup: Union[
-            "types.InlineKeyboardMarkup",
-            "types.ReplyKeyboardMarkup",
-            "types.ReplyKeyboardRemove",
-            "types.ForceReply",
-        ] = None,
-        progress: Optional[Callable] = None,
+        thumb: str | None = None,
+        disable_notification: bool | None = None,
+        reply_to_message_id: int | None = None,
+        reply_markup: types.InlineKeyboardMarkup
+        | types.ReplyKeyboardMarkup
+        | types.ReplyKeyboardRemove
+        | types.ForceReply = None,
+        progress: Callable | None = None,
         progress_args: tuple = (),
-    ) -> "Message":
+    ) -> Message:
         """Bound method *reply_video_note* of :obj:`~hydrogram.types.Message`.
 
         Use as a shortcut for:
@@ -3010,23 +2986,21 @@ class Message(Object, Update):
 
     async def reply_voice(
         self,
-        voice: Union[str, BinaryIO],
-        quote: Optional[bool] = None,
+        voice: str | BinaryIO,
+        quote: bool | None = None,
         caption: str = "",
-        parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: Optional[list["types.MessageEntity"]] = None,
+        parse_mode: enums.ParseMode | None = None,
+        caption_entities: list[types.MessageEntity] | None = None,
         duration: int = 0,
-        disable_notification: Optional[bool] = None,
-        reply_to_message_id: Optional[int] = None,
-        reply_markup: Union[
-            "types.InlineKeyboardMarkup",
-            "types.ReplyKeyboardMarkup",
-            "types.ReplyKeyboardRemove",
-            "types.ForceReply",
-        ] = None,
-        progress: Optional[Callable] = None,
+        disable_notification: bool | None = None,
+        reply_to_message_id: int | None = None,
+        reply_markup: types.InlineKeyboardMarkup
+        | types.ReplyKeyboardMarkup
+        | types.ReplyKeyboardRemove
+        | types.ForceReply = None,
+        progress: Callable | None = None,
         progress_args: tuple = (),
-    ) -> "Message":
+    ) -> Message:
         """Bound method *reply_voice* of :obj:`~hydrogram.types.Message`.
 
         Use as a shortcut for:
@@ -3132,11 +3106,11 @@ class Message(Object, Update):
     async def edit_text(
         self,
         text: str,
-        parse_mode: Optional["enums.ParseMode"] = None,
-        entities: Optional[list["types.MessageEntity"]] = None,
-        disable_web_page_preview: Optional[bool] = None,
-        reply_markup: "types.InlineKeyboardMarkup" = None,
-    ) -> "Message":
+        parse_mode: enums.ParseMode | None = None,
+        entities: list[types.MessageEntity] | None = None,
+        disable_web_page_preview: bool | None = None,
+        reply_markup: types.InlineKeyboardMarkup = None,
+    ) -> Message:
         """Bound method *edit_text* of :obj:`~hydrogram.types.Message`.
 
         An alias exists as *edit*.
@@ -3192,10 +3166,10 @@ class Message(Object, Update):
     async def edit_caption(
         self,
         caption: str,
-        parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: Optional[list["types.MessageEntity"]] = None,
-        reply_markup: "types.InlineKeyboardMarkup" = None,
-    ) -> "Message":
+        parse_mode: enums.ParseMode | None = None,
+        caption_entities: list[types.MessageEntity] | None = None,
+        reply_markup: types.InlineKeyboardMarkup = None,
+    ) -> Message:
         """Bound method *edit_caption* of :obj:`~hydrogram.types.Message`.
 
         Use as a shortcut for:
@@ -3242,9 +3216,9 @@ class Message(Object, Update):
 
     async def edit_media(
         self,
-        media: "types.InputMedia",
-        reply_markup: "types.InlineKeyboardMarkup" = None,
-    ) -> "Message":
+        media: types.InputMedia,
+        reply_markup: types.InlineKeyboardMarkup = None,
+    ) -> Message:
         """Bound method *edit_media* of :obj:`~hydrogram.types.Message`.
 
         Use as a shortcut for:
@@ -3280,9 +3254,7 @@ class Message(Object, Update):
             reply_markup=reply_markup,
         )
 
-    async def edit_reply_markup(
-        self, reply_markup: "types.InlineKeyboardMarkup" = None
-    ) -> "Message":
+    async def edit_reply_markup(self, reply_markup: types.InlineKeyboardMarkup = None) -> Message:
         """Bound method *edit_reply_markup* of :obj:`~hydrogram.types.Message`.
 
         Use as a shortcut for:
@@ -3315,11 +3287,11 @@ class Message(Object, Update):
 
     async def forward(
         self,
-        chat_id: Union[int, str],
-        message_thread_id: Optional[int] = None,
-        disable_notification: Optional[bool] = None,
-        schedule_date: Optional[datetime] = None,
-    ) -> Union["types.Message", list["types.Message"]]:
+        chat_id: int | str,
+        message_thread_id: int | None = None,
+        disable_notification: bool | None = None,
+        schedule_date: datetime | None = None,
+    ) -> types.Message | list[types.Message]:
         """Bound method *forward* of :obj:`~hydrogram.types.Message`.
 
         Use as a shortcut for:
@@ -3368,22 +3340,20 @@ class Message(Object, Update):
 
     async def copy(
         self,
-        chat_id: Union[int, str],
-        caption: Optional[str] = None,
-        message_thread_id: Optional[int] = None,
-        parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: Optional[list["types.MessageEntity"]] = None,
-        disable_notification: Optional[bool] = None,
-        reply_to_message_id: Optional[int] = None,
-        schedule_date: Optional[datetime] = None,
-        protect_content: Optional[bool] = None,
-        reply_markup: Union[
-            "types.InlineKeyboardMarkup",
-            "types.ReplyKeyboardMarkup",
-            "types.ReplyKeyboardRemove",
-            "types.ForceReply",
-        ] = object,
-    ) -> Union["types.Message", list["types.Message"]]:
+        chat_id: int | str,
+        caption: str | None = None,
+        message_thread_id: int | None = None,
+        parse_mode: enums.ParseMode | None = None,
+        caption_entities: list[types.MessageEntity] | None = None,
+        disable_notification: bool | None = None,
+        reply_to_message_id: int | None = None,
+        schedule_date: datetime | None = None,
+        protect_content: bool | None = None,
+        reply_markup: types.InlineKeyboardMarkup
+        | types.ReplyKeyboardMarkup
+        | types.ReplyKeyboardRemove
+        | types.ForceReply = object,
+    ) -> types.Message | list[types.Message]:
         """Bound method *copy* of :obj:`~hydrogram.types.Message`.
 
         Use as a shortcut for:
@@ -3606,9 +3576,9 @@ class Message(Object, Update):
 
     async def click(
         self,
-        x: Union[int, str] = 0,
-        y: Optional[int] = None,
-        quote: Optional[bool] = None,
+        x: int | str = 0,
+        y: int | None = None,
+        quote: bool | None = None,
         timeout: int = 10,
     ):
         """Bound method *click* of :obj:`~hydrogram.types.Message`.
@@ -3754,7 +3724,7 @@ class Message(Object, Update):
 
     async def retract_vote(
         self,
-    ) -> "types.Poll":
+    ) -> types.Poll:
         """Bound method *retract_vote* of :obj:`~hydrogram.types.Message`.
 
         Use as a shortcut for:
@@ -3785,7 +3755,7 @@ class Message(Object, Update):
         file_name: str = "",
         in_memory: bool = False,
         block: bool = True,
-        progress: Optional[Callable] = None,
+        progress: Callable | None = None,
         progress_args: tuple = (),
     ) -> str:
         """Bound method *download* of :obj:`~hydrogram.types.Message`.
@@ -3858,7 +3828,7 @@ class Message(Object, Update):
     async def vote(
         self,
         option: int,
-    ) -> "types.Poll":
+    ) -> types.Poll:
         """Bound method *vote* of :obj:`~hydrogram.types.Message`.
 
         Use as a shortcut for:
@@ -3889,7 +3859,7 @@ class Message(Object, Update):
 
     async def pin(
         self, disable_notification: bool = False, both_sides: bool = False
-    ) -> "types.Message":
+    ) -> types.Message:
         """Bound method *pin* of :obj:`~hydrogram.types.Message`.
 
         Use as a shortcut for:

--- a/hydrogram/types/messages_and_media/message_entity.py
+++ b/hydrogram/types/messages_and_media/message_entity.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import enums, raw, types
@@ -56,14 +56,14 @@ class MessageEntity(Object):
     def __init__(
         self,
         *,
-        client: "hydrogram.Client" = None,
-        type: "enums.MessageEntityType",
+        client: hydrogram.Client = None,
+        type: enums.MessageEntityType,
         offset: int,
         length: int,
-        url: Optional[str] = None,
-        user: "types.User" = None,
-        language: Optional[str] = None,
-        custom_emoji_id: Optional[int] = None,
+        url: str | None = None,
+        user: types.User = None,
+        language: str | None = None,
+        custom_emoji_id: int | None = None,
     ):
         super().__init__(client)
 
@@ -76,7 +76,7 @@ class MessageEntity(Object):
         self.custom_emoji_id = custom_emoji_id
 
     @staticmethod
-    def _parse(client, entity: "raw.base.MessageEntity", users: dict) -> Optional["MessageEntity"]:
+    def _parse(client, entity: raw.base.MessageEntity, users: dict) -> MessageEntity | None:
         # Special case for InputMessageEntityMentionName -> MessageEntityType.TEXT_MENTION
         # This happens in case of UpdateShortSentMessage inside send_message() where entities are parsed from the input
         if isinstance(entity, raw.types.InputMessageEntityMentionName):

--- a/hydrogram/types/messages_and_media/message_reactions.py
+++ b/hydrogram/types/messages_and_media/message_reactions.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw, types
@@ -35,8 +35,8 @@ class MessageReactions(Object):
     def __init__(
         self,
         *,
-        client: "hydrogram.Client" = None,
-        reactions: Optional[list["types.Reaction"]] = None,
+        client: hydrogram.Client = None,
+        reactions: list[types.Reaction] | None = None,
     ):
         super().__init__(client)
 
@@ -44,9 +44,9 @@ class MessageReactions(Object):
 
     @staticmethod
     def _parse(
-        client: "hydrogram.Client",
-        message_reactions: Optional["raw.base.MessageReactions"] = None,
-    ) -> Optional["MessageReactions"]:
+        client: hydrogram.Client,
+        message_reactions: raw.base.MessageReactions | None = None,
+    ) -> MessageReactions | None:
         if not message_reactions:
             return None
 

--- a/hydrogram/types/messages_and_media/photo.py
+++ b/hydrogram/types/messages_and_media/photo.py
@@ -17,8 +17,9 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from datetime import datetime
-from typing import Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import hydrogram
 from hydrogram import raw, types, utils
@@ -30,6 +31,9 @@ from hydrogram.file_id import (
     ThumbnailSource,
 )
 from hydrogram.types.object import Object
+
+if TYPE_CHECKING:
+    from datetime import datetime
 
 
 class Photo(Object):
@@ -65,15 +69,15 @@ class Photo(Object):
     def __init__(
         self,
         *,
-        client: "hydrogram.Client" = None,
+        client: hydrogram.Client = None,
         file_id: str,
         file_unique_id: str,
         width: int,
         height: int,
         file_size: int,
         date: datetime,
-        ttl_seconds: Optional[int] = None,
-        thumbs: Optional[list["types.Thumbnail"]] = None,
+        ttl_seconds: int | None = None,
+        thumbs: list[types.Thumbnail] | None = None,
     ):
         super().__init__(client)
 
@@ -87,7 +91,7 @@ class Photo(Object):
         self.thumbs = thumbs
 
     @staticmethod
-    def _parse(client, photo: "raw.types.Photo", ttl_seconds: Optional[int] = None) -> "Photo":
+    def _parse(client, photo: raw.types.Photo, ttl_seconds: int | None = None) -> Photo:
         if isinstance(photo, raw.types.Photo):
             photos: list[raw.types.PhotoSize] = []
 

--- a/hydrogram/types/messages_and_media/poll.py
+++ b/hydrogram/types/messages_and_media/poll.py
@@ -17,13 +17,17 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from datetime import datetime
-from typing import Optional, Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import hydrogram
 from hydrogram import enums, raw, types, utils
 from hydrogram.types.object import Object
 from hydrogram.types.update import Update
+
+if TYPE_CHECKING:
+    from datetime import datetime
 
 
 class Poll(Object, Update):
@@ -79,21 +83,21 @@ class Poll(Object, Update):
     def __init__(
         self,
         *,
-        client: "hydrogram.Client" = None,
+        client: hydrogram.Client = None,
         id: str,
         question: str,
-        options: list["types.PollOption"],
+        options: list[types.PollOption],
         total_voter_count: int,
         is_closed: bool,
-        is_anonymous: Optional[bool] = None,
-        type: "enums.PollType" = None,
-        allows_multiple_answers: Optional[bool] = None,
-        chosen_option_id: Optional[int] = None,
-        correct_option_id: Optional[int] = None,
-        explanation: Optional[str] = None,
-        explanation_entities: Optional[list["types.MessageEntity"]] = None,
-        open_period: Optional[int] = None,
-        close_date: Optional[datetime] = None,
+        is_anonymous: bool | None = None,
+        type: enums.PollType = None,
+        allows_multiple_answers: bool | None = None,
+        chosen_option_id: int | None = None,
+        correct_option_id: int | None = None,
+        explanation: str | None = None,
+        explanation_entities: list[types.MessageEntity] | None = None,
+        open_period: int | None = None,
+        close_date: datetime | None = None,
     ):
         super().__init__(client)
 
@@ -115,8 +119,8 @@ class Poll(Object, Update):
     @staticmethod
     def _parse(
         client,
-        media_poll: Union["raw.types.MessageMediaPoll", "raw.types.UpdateMessagePoll"],
-    ) -> "Poll":
+        media_poll: raw.types.MessageMediaPoll | raw.types.UpdateMessagePoll,
+    ) -> Poll:
         poll: raw.types.Poll = media_poll.poll
         poll_results: raw.types.PollResults = media_poll.results
         results: list[raw.types.PollAnswerVoters] = poll_results.results
@@ -170,7 +174,7 @@ class Poll(Object, Update):
         )
 
     @staticmethod
-    def _parse_update(client, update: "raw.types.UpdateMessagePoll"):
+    def _parse_update(client, update: raw.types.UpdateMessagePoll):
         if update.poll is not None:
             return Poll._parse(client, update)
 

--- a/hydrogram/types/messages_and_media/poll_option.py
+++ b/hydrogram/types/messages_and_media/poll_option.py
@@ -17,8 +17,12 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-import hydrogram
+from typing import TYPE_CHECKING
+
 from hydrogram.types.object import Object
+
+if TYPE_CHECKING:
+    import hydrogram
 
 
 class PollOption(Object):

--- a/hydrogram/types/messages_and_media/reaction.py
+++ b/hydrogram/types/messages_and_media/reaction.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
@@ -45,11 +45,11 @@ class Reaction(Object):
     def __init__(
         self,
         *,
-        client: "hydrogram.Client" = None,
-        emoji: Optional[str] = None,
-        custom_emoji_id: Optional[int] = None,
-        count: Optional[int] = None,
-        chosen_order: Optional[int] = None,
+        client: hydrogram.Client = None,
+        emoji: str | None = None,
+        custom_emoji_id: int | None = None,
+        count: int | None = None,
+        chosen_order: int | None = None,
     ):
         super().__init__(client)
 
@@ -59,7 +59,7 @@ class Reaction(Object):
         self.chosen_order = chosen_order
 
     @staticmethod
-    def _parse(client: "hydrogram.Client", reaction: "raw.base.Reaction") -> "Reaction":
+    def _parse(client: hydrogram.Client, reaction: raw.base.Reaction) -> Reaction:
         if isinstance(reaction, raw.types.ReactionEmoji):
             return Reaction(client=client, emoji=reaction.emoticon)
 
@@ -68,9 +68,7 @@ class Reaction(Object):
         return None
 
     @staticmethod
-    def _parse_count(
-        client: "hydrogram.Client", reaction_count: "raw.base.ReactionCount"
-    ) -> "Reaction":
+    def _parse_count(client: hydrogram.Client, reaction_count: raw.base.ReactionCount) -> Reaction:
         reaction = Reaction._parse(client, reaction_count.reaction)
         reaction.count = reaction_count.count
         reaction.chosen_order = reaction_count.chosen_order

--- a/hydrogram/types/messages_and_media/sticker.py
+++ b/hydrogram/types/messages_and_media/sticker.py
@@ -17,14 +17,18 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from datetime import datetime
-from typing import ClassVar, Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, ClassVar
 
 import hydrogram
 from hydrogram import raw, types, utils
 from hydrogram.errors import StickersetInvalid
 from hydrogram.file_id import FileId, FileType, FileUniqueId, FileUniqueType
 from hydrogram.types.object import Object
+
+if TYPE_CHECKING:
+    from datetime import datetime
 
 
 class Sticker(Object):
@@ -77,20 +81,20 @@ class Sticker(Object):
     def __init__(
         self,
         *,
-        client: "hydrogram.Client" = None,
+        client: hydrogram.Client = None,
         file_id: str,
         file_unique_id: str,
         width: int,
         height: int,
         is_animated: bool,
         is_video: bool,
-        file_name: Optional[str] = None,
-        mime_type: Optional[str] = None,
-        file_size: Optional[int] = None,
-        date: Optional[datetime] = None,
-        emoji: Optional[str] = None,
-        set_name: Optional[str] = None,
-        thumbs: Optional[list["types.Thumbnail"]] = None,
+        file_name: str | None = None,
+        mime_type: str | None = None,
+        file_size: int | None = None,
+        date: datetime | None = None,
+        emoji: str | None = None,
+        set_name: str | None = None,
+        thumbs: list[types.Thumbnail] | None = None,
     ):
         super().__init__(client)
 
@@ -146,11 +150,9 @@ class Sticker(Object):
     @staticmethod
     async def _parse(
         client,
-        sticker: "raw.types.Document",
-        document_attributes: dict[
-            type["raw.base.DocumentAttribute"], "raw.base.DocumentAttribute"
-        ],
-    ) -> "Sticker":
+        sticker: raw.types.Document,
+        document_attributes: dict[type[raw.base.DocumentAttribute], raw.base.DocumentAttribute],
+    ) -> Sticker:
         sticker_attributes = (
             document_attributes.get(raw.types.DocumentAttributeSticker)
             or document_attributes[raw.types.DocumentAttributeCustomEmoji]

--- a/hydrogram/types/messages_and_media/stripped_thumbnail.py
+++ b/hydrogram/types/messages_and_media/stripped_thumbnail.py
@@ -17,9 +17,13 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-import hydrogram
-from hydrogram import raw
+from typing import TYPE_CHECKING
+
 from hydrogram.types.object import Object
+
+if TYPE_CHECKING:
+    import hydrogram
+    from hydrogram import raw
 
 
 class StrippedThumbnail(Object):

--- a/hydrogram/types/messages_and_media/thumbnail.py
+++ b/hydrogram/types/messages_and_media/thumbnail.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional, Union
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
@@ -55,7 +55,7 @@ class Thumbnail(Object):
     def __init__(
         self,
         *,
-        client: "hydrogram.Client" = None,
+        client: hydrogram.Client = None,
         file_id: str,
         file_unique_id: str,
         width: int,
@@ -71,9 +71,7 @@ class Thumbnail(Object):
         self.file_size = file_size
 
     @staticmethod
-    def _parse(
-        client, media: Union["raw.types.Photo", "raw.types.Document"]
-    ) -> Optional[list["Thumbnail"]]:
+    def _parse(client, media: raw.types.Photo | raw.types.Document) -> list[Thumbnail] | None:
         if isinstance(media, raw.types.Photo):
             raw_thumbs = [i for i in media.sizes if isinstance(i, raw.types.PhotoSize)]
             raw_thumbs.sort(key=lambda p: p.size)

--- a/hydrogram/types/messages_and_media/venue.py
+++ b/hydrogram/types/messages_and_media/venue.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw, types
@@ -49,12 +49,12 @@ class Venue(Object):
     def __init__(
         self,
         *,
-        client: "hydrogram.Client" = None,
-        location: "types.Location",
+        client: hydrogram.Client = None,
+        location: types.Location,
         title: str,
         address: str,
-        foursquare_id: Optional[str] = None,
-        foursquare_type: Optional[str] = None,
+        foursquare_id: str | None = None,
+        foursquare_type: str | None = None,
     ):
         super().__init__(client)
 
@@ -65,7 +65,7 @@ class Venue(Object):
         self.foursquare_type = foursquare_type
 
     @staticmethod
-    def _parse(client, venue: "raw.types.MessageMediaVenue"):
+    def _parse(client, venue: raw.types.MessageMediaVenue):
         return Venue(
             location=types.Location._parse(client, venue.geo),
             title=venue.title,

--- a/hydrogram/types/messages_and_media/video.py
+++ b/hydrogram/types/messages_and_media/video.py
@@ -17,13 +17,17 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from datetime import datetime
-from typing import Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import hydrogram
 from hydrogram import raw, types, utils
 from hydrogram.file_id import FileId, FileType, FileUniqueId, FileUniqueType
 from hydrogram.types.object import Object
+
+if TYPE_CHECKING:
+    from datetime import datetime
 
 
 class Video(Object):
@@ -71,19 +75,19 @@ class Video(Object):
     def __init__(
         self,
         *,
-        client: "hydrogram.Client" = None,
+        client: hydrogram.Client = None,
         file_id: str,
         file_unique_id: str,
         width: int,
         height: int,
         duration: int,
-        file_name: Optional[str] = None,
-        mime_type: Optional[str] = None,
-        file_size: Optional[int] = None,
-        supports_streaming: Optional[bool] = None,
-        ttl_seconds: Optional[int] = None,
-        date: Optional[datetime] = None,
-        thumbs: Optional[list["types.Thumbnail"]] = None,
+        file_name: str | None = None,
+        mime_type: str | None = None,
+        file_size: int | None = None,
+        supports_streaming: bool | None = None,
+        ttl_seconds: int | None = None,
+        date: datetime | None = None,
+        thumbs: list[types.Thumbnail] | None = None,
     ):
         super().__init__(client)
 
@@ -103,11 +107,11 @@ class Video(Object):
     @staticmethod
     def _parse(
         client,
-        video: "raw.types.Document",
-        video_attributes: "raw.types.DocumentAttributeVideo",
+        video: raw.types.Document,
+        video_attributes: raw.types.DocumentAttributeVideo,
         file_name: str,
-        ttl_seconds: Optional[int] = None,
-    ) -> "Video":
+        ttl_seconds: int | None = None,
+    ) -> Video:
         return Video(
             file_id=FileId(
                 file_type=FileType.VIDEO,

--- a/hydrogram/types/messages_and_media/video_note.py
+++ b/hydrogram/types/messages_and_media/video_note.py
@@ -17,13 +17,17 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from datetime import datetime
-from typing import Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import hydrogram
 from hydrogram import raw, types, utils
 from hydrogram.file_id import FileId, FileType, FileUniqueId, FileUniqueType
 from hydrogram.types.object import Object
+
+if TYPE_CHECKING:
+    from datetime import datetime
 
 
 class VideoNote(Object):
@@ -59,15 +63,15 @@ class VideoNote(Object):
     def __init__(
         self,
         *,
-        client: "hydrogram.Client" = None,
+        client: hydrogram.Client = None,
         file_id: str,
         file_unique_id: str,
         length: int,
         duration: int,
-        thumbs: Optional[list["types.Thumbnail"]] = None,
-        mime_type: Optional[str] = None,
-        file_size: Optional[int] = None,
-        date: Optional[datetime] = None,
+        thumbs: list[types.Thumbnail] | None = None,
+        mime_type: str | None = None,
+        file_size: int | None = None,
+        date: datetime | None = None,
     ):
         super().__init__(client)
 
@@ -83,9 +87,9 @@ class VideoNote(Object):
     @staticmethod
     def _parse(
         client,
-        video_note: "raw.types.Document",
-        video_attributes: "raw.types.DocumentAttributeVideo",
-    ) -> "VideoNote":
+        video_note: raw.types.Document,
+        video_attributes: raw.types.DocumentAttributeVideo,
+    ) -> VideoNote:
         return VideoNote(
             file_id=FileId(
                 file_type=FileType.VIDEO_NOTE,

--- a/hydrogram/types/messages_and_media/voice.py
+++ b/hydrogram/types/messages_and_media/voice.py
@@ -17,13 +17,17 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from datetime import datetime
-from typing import Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import hydrogram
 from hydrogram import raw, utils
 from hydrogram.file_id import FileId, FileType, FileUniqueId, FileUniqueType
 from hydrogram.types.object import Object
+
+if TYPE_CHECKING:
+    from datetime import datetime
 
 
 class Voice(Object):
@@ -56,14 +60,14 @@ class Voice(Object):
     def __init__(
         self,
         *,
-        client: "hydrogram.Client" = None,
+        client: hydrogram.Client = None,
         file_id: str,
         file_unique_id: str,
         duration: int,
-        waveform: Optional[bytes] = None,
-        mime_type: Optional[str] = None,
-        file_size: Optional[int] = None,
-        date: Optional[datetime] = None,
+        waveform: bytes | None = None,
+        mime_type: str | None = None,
+        file_size: int | None = None,
+        date: datetime | None = None,
     ):
         super().__init__(client)
 
@@ -78,9 +82,9 @@ class Voice(Object):
     @staticmethod
     def _parse(
         client,
-        voice: "raw.types.Document",
-        attributes: "raw.types.DocumentAttributeAudio",
-    ) -> "Voice":
+        voice: raw.types.Document,
+        attributes: raw.types.DocumentAttributeAudio,
+    ) -> Voice:
         return Voice(
             file_id=FileId(
                 file_type=FileType.VOICE,

--- a/hydrogram/types/messages_and_media/web_app_data.py
+++ b/hydrogram/types/messages_and_media/web_app_data.py
@@ -17,8 +17,12 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from hydrogram import raw
+from typing import TYPE_CHECKING
+
 from hydrogram.types.object import Object
+
+if TYPE_CHECKING:
+    from hydrogram import raw
 
 
 class WebAppData(Object):

--- a/hydrogram/types/messages_and_media/web_page.py
+++ b/hydrogram/types/messages_and_media/web_page.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw, types
@@ -89,25 +89,25 @@ class WebPage(Object):
     def __init__(
         self,
         *,
-        client: "hydrogram.Client" = None,
+        client: hydrogram.Client = None,
         id: str,
         url: str,
         display_url: str,
-        type: Optional[str] = None,
-        site_name: Optional[str] = None,
-        title: Optional[str] = None,
-        description: Optional[str] = None,
-        audio: "types.Audio" = None,
-        document: "types.Document" = None,
-        photo: "types.Photo" = None,
-        animation: "types.Animation" = None,
-        video: "types.Video" = None,
-        embed_url: Optional[str] = None,
-        embed_type: Optional[str] = None,
-        embed_width: Optional[int] = None,
-        embed_height: Optional[int] = None,
-        duration: Optional[int] = None,
-        author: Optional[str] = None,
+        type: str | None = None,
+        site_name: str | None = None,
+        title: str | None = None,
+        description: str | None = None,
+        audio: types.Audio = None,
+        document: types.Document = None,
+        photo: types.Photo = None,
+        animation: types.Animation = None,
+        video: types.Video = None,
+        embed_url: str | None = None,
+        embed_type: str | None = None,
+        embed_width: int | None = None,
+        embed_height: int | None = None,
+        duration: int | None = None,
+        author: str | None = None,
     ):
         super().__init__(client)
 
@@ -131,7 +131,7 @@ class WebPage(Object):
         self.author = author
 
     @staticmethod
-    def _parse(client, webpage: "raw.types.WebPage") -> "WebPage":
+    def _parse(client, webpage: raw.types.WebPage) -> WebPage:
         audio = None
         document = None
         photo = None

--- a/hydrogram/types/object.py
+++ b/hydrogram/types/object.py
@@ -22,7 +22,8 @@ from datetime import datetime
 from enum import Enum
 from json import dumps
 
-import hydrogram
+if typing.TYPE_CHECKING:
+    import hydrogram
 
 
 class Object:

--- a/hydrogram/types/pyromod/identifier.py
+++ b/hydrogram/types/pyromod/identifier.py
@@ -17,18 +17,19 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 from dataclasses import dataclass
-from typing import Optional, Union
 
 
 @dataclass
 class Identifier:
-    inline_message_id: Optional[Union[str, list[str]]] = None
-    chat_id: Optional[Union[int, str, list[Union[int, str]]]] = None
-    message_id: Optional[Union[int, list[int]]] = None
-    from_user_id: Optional[Union[int, str, list[Union[int, str]]]] = None
+    inline_message_id: str | list[str] | None = None
+    chat_id: int | str | list[int | str] | None = None
+    message_id: int | list[int] | None = None
+    from_user_id: int | str | list[int | str] | None = None
 
-    def matches(self, update: "Identifier") -> bool:
+    def matches(self, update: Identifier) -> bool:
         # Compare each property of other with the corresponding property in self
         # If the property in self is None, the property in other can be anything
         # If the property in self is not None, the property in other must be the same

--- a/hydrogram/types/pyromod/listener.py
+++ b/hydrogram/types/pyromod/listener.py
@@ -19,12 +19,13 @@
 
 from asyncio import Future
 from dataclasses import dataclass
-from typing import Callable
-
-import hydrogram
+from typing import TYPE_CHECKING, Callable
 
 from .identifier import Identifier
 from .listener_types import ListenerTypes
+
+if TYPE_CHECKING:
+    import hydrogram
 
 
 @dataclass

--- a/hydrogram/types/user_and_chats/chat.py
+++ b/hydrogram/types/user_and_chats/chat.py
@@ -17,14 +17,18 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from collections.abc import AsyncGenerator
-from datetime import datetime
-from typing import BinaryIO, Optional, Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, BinaryIO
 
 import hydrogram
 from hydrogram import enums, filters, raw, types, utils
 from hydrogram.types import ListenerTypes
 from hydrogram.types.object import Object
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+    from datetime import datetime
 
 
 class Chat(Object):
@@ -150,39 +154,39 @@ class Chat(Object):
     def __init__(
         self,
         *,
-        client: "hydrogram.Client" = None,
+        client: hydrogram.Client = None,
         id: int,
-        type: "enums.ChatType",
-        is_verified: Optional[bool] = None,
-        is_participants_hidden: Optional[bool] = None,
-        is_restricted: Optional[bool] = None,
-        is_creator: Optional[bool] = None,
-        is_scam: Optional[bool] = None,
-        is_fake: Optional[bool] = None,
-        is_support: Optional[bool] = None,
-        is_forum: Optional[bool] = None,
-        title: Optional[str] = None,
-        username: Optional[str] = None,
-        active_usernames: Optional[str] = None,
-        usernames: Optional[list["types.Username"]] = None,
-        first_name: Optional[str] = None,
-        last_name: Optional[str] = None,
-        photo: "types.ChatPhoto" = None,
-        bio: Optional[str] = None,
-        description: Optional[str] = None,
-        dc_id: Optional[int] = None,
-        has_protected_content: Optional[bool] = None,
-        invite_link: Optional[str] = None,
+        type: enums.ChatType,
+        is_verified: bool | None = None,
+        is_participants_hidden: bool | None = None,
+        is_restricted: bool | None = None,
+        is_creator: bool | None = None,
+        is_scam: bool | None = None,
+        is_fake: bool | None = None,
+        is_support: bool | None = None,
+        is_forum: bool | None = None,
+        title: str | None = None,
+        username: str | None = None,
+        active_usernames: str | None = None,
+        usernames: list[types.Username] | None = None,
+        first_name: str | None = None,
+        last_name: str | None = None,
+        photo: types.ChatPhoto = None,
+        bio: str | None = None,
+        description: str | None = None,
+        dc_id: int | None = None,
+        has_protected_content: bool | None = None,
+        invite_link: str | None = None,
         pinned_message=None,
-        sticker_set_name: Optional[str] = None,
-        can_set_sticker_set: Optional[bool] = None,
-        members_count: Optional[int] = None,
-        restrictions: Optional[list["types.Restriction"]] = None,
-        permissions: "types.ChatPermissions" = None,
-        distance: Optional[int] = None,
-        linked_chat: "types.Chat" = None,
-        send_as_chat: "types.Chat" = None,
-        available_reactions: Optional["types.ChatReactions"] = None,
+        sticker_set_name: str | None = None,
+        can_set_sticker_set: bool | None = None,
+        members_count: int | None = None,
+        restrictions: list[types.Restriction] | None = None,
+        permissions: types.ChatPermissions = None,
+        distance: int | None = None,
+        linked_chat: types.Chat = None,
+        send_as_chat: types.Chat = None,
+        available_reactions: types.ChatReactions | None = None,
     ):
         super().__init__(client)
 
@@ -224,7 +228,7 @@ class Chat(Object):
         return " ".join(filter(None, [self.first_name, self.last_name])) or None
 
     @staticmethod
-    def _parse_user_chat(client, user: raw.types.User) -> "Chat":
+    def _parse_user_chat(client, user: raw.types.User) -> Chat:
         peer_id = user.id
 
         return Chat(
@@ -251,7 +255,7 @@ class Chat(Object):
         )
 
     @staticmethod
-    def _parse_chat_chat(client, chat: raw.types.Chat) -> "Chat":
+    def _parse_chat_chat(client, chat: raw.types.Chat) -> Chat:
         peer_id = -chat.id
         usernames = getattr(chat, "usernames", [])
 
@@ -270,7 +274,7 @@ class Chat(Object):
         )
 
     @staticmethod
-    def _parse_channel_chat(client, channel: raw.types.Channel) -> "Chat":
+    def _parse_channel_chat(client, channel: raw.types.Channel) -> Chat:
         peer_id = utils.get_channel_id(channel.id)
         restriction_reason = getattr(channel, "restriction_reason", [])
         usernames = getattr(channel, "usernames", [])
@@ -309,11 +313,11 @@ class Chat(Object):
     @staticmethod
     def _parse(
         client,
-        message: Union[raw.types.Message, raw.types.MessageService],
+        message: raw.types.Message | raw.types.MessageService,
         users: dict,
         chats: dict,
         is_chat: bool,
-    ) -> "Chat":
+    ) -> Chat:
         from_id = utils.get_raw_peer_id(message.from_id)
         peer_id = utils.get_raw_peer_id(message.peer_id)
         chat_id = (peer_id or from_id) if is_chat else (from_id or peer_id)
@@ -336,8 +340,8 @@ class Chat(Object):
 
     @staticmethod
     async def _parse_full(
-        client, chat_full: Union[raw.types.messages.ChatFull, raw.types.users.UserFull]
-    ) -> "Chat":
+        client, chat_full: raw.types.messages.ChatFull | raw.types.users.UserFull
+    ) -> Chat:
         users = {u.id: u for u in chat_full.users}
         chats = {c.id: c for c in chat_full.chats}
 
@@ -397,9 +401,7 @@ class Chat(Object):
         return parsed_chat
 
     @staticmethod
-    def _parse_chat(
-        client, chat: Union[raw.types.Chat, raw.types.User, raw.types.Channel]
-    ) -> "Chat":
+    def _parse_chat(client, chat: raw.types.Chat | raw.types.User | raw.types.Channel) -> Chat:
         if isinstance(chat, raw.types.Chat):
             return Chat._parse_chat_chat(client, chat)
         if isinstance(chat, raw.types.User):
@@ -408,13 +410,13 @@ class Chat(Object):
 
     def listen(
         self,
-        filters: Optional["filters.Filter"] = None,
+        filters: filters.Filter | None = None,
         listener_type: ListenerTypes = ListenerTypes.MESSAGE,
-        timeout: Optional[int] = None,
+        timeout: int | None = None,
         unallowed_click_alert: bool = True,
-        user_id: Optional[Union[int, str, list[Union[int, str]]]] = None,
-        message_id: Optional[Union[int, list[int]]] = None,
-        inline_message_id: Optional[Union[str, list[str]]] = None,
+        user_id: int | str | list[int | str] | None = None,
+        message_id: int | list[int] | None = None,
+        inline_message_id: str | list[str] | None = None,
     ):
         """
         Bound method *listen* of :obj:`~hydrogram.types.Chat`.
@@ -469,13 +471,13 @@ class Chat(Object):
     def ask(
         self,
         text: str,
-        filters: Optional["filters.Filter"] = None,
+        filters: filters.Filter | None = None,
         listener_type: ListenerTypes = ListenerTypes.MESSAGE,
-        timeout: Optional[int] = None,
+        timeout: int | None = None,
         unallowed_click_alert: bool = True,
-        user_id: Optional[Union[int, str, list[Union[int, str]]]] = None,
-        message_id: Optional[Union[int, list[int]]] = None,
-        inline_message_id: Optional[Union[str, list[str]]] = None,
+        user_id: int | str | list[int | str] | None = None,
+        message_id: int | list[int] | None = None,
+        inline_message_id: str | list[str] | None = None,
         *args,
         **kwargs,
     ):
@@ -545,9 +547,9 @@ class Chat(Object):
     def stop_listening(
         self,
         listener_type: ListenerTypes = ListenerTypes.MESSAGE,
-        user_id: Optional[Union[int, str, list[Union[int, str]]]] = None,
-        message_id: Optional[Union[int, list[int]]] = None,
-        inline_message_id: Optional[Union[str, list[str]]] = None,
+        user_id: int | str | list[int | str] | None = None,
+        message_id: int | list[int] | None = None,
+        inline_message_id: str | list[str] | None = None,
     ):
         """
         Bound method *stop_listening* of :obj:`~hydrogram.types.Chat`.
@@ -697,9 +699,9 @@ class Chat(Object):
     async def set_photo(
         self,
         *,
-        photo: Optional[Union[str, BinaryIO]] = None,
-        video: Optional[Union[str, BinaryIO]] = None,
-        video_start_ts: Optional[float] = None,
+        photo: str | BinaryIO | None = None,
+        video: str | BinaryIO | None = None,
+        video_start_ts: float | None = None,
     ) -> bool:
         """Bound method *set_photo* of :obj:`~hydrogram.types.Chat`.
 
@@ -752,8 +754,8 @@ class Chat(Object):
         )
 
     async def ban_member(
-        self, user_id: Union[int, str], until_date: datetime = utils.zero_datetime()
-    ) -> Union["types.Message", bool]:
+        self, user_id: int | str, until_date: datetime = utils.zero_datetime()
+    ) -> types.Message | bool:
         """Bound method *ban_member* of :obj:`~hydrogram.types.Chat`.
 
         Use as a shortcut for:
@@ -794,7 +796,7 @@ class Chat(Object):
             chat_id=self.id, user_id=user_id, until_date=until_date
         )
 
-    async def unban_member(self, user_id: Union[int, str]) -> bool:
+    async def unban_member(self, user_id: int | str) -> bool:
         """Bound method *unban_member* of :obj:`~hydrogram.types.Chat`.
 
         Use as a shortcut for:
@@ -827,10 +829,10 @@ class Chat(Object):
 
     async def restrict_member(
         self,
-        user_id: Union[int, str],
-        permissions: "types.ChatPermissions",
+        user_id: int | str,
+        permissions: types.ChatPermissions,
         until_date: datetime = utils.zero_datetime(),
-    ) -> "types.Chat":
+    ) -> types.Chat:
         """Bound method *unban_member* of :obj:`~hydrogram.types.Chat`.
 
         Use as a shortcut for:
@@ -876,7 +878,7 @@ class Chat(Object):
     # Set None as privileges default due to issues with partially initialized module, because at the time Chat
     # is being initialized, ChatPrivileges would be required here, but was not initialized yet.
     async def promote_member(
-        self, user_id: Union[int, str], privileges: "types.ChatPrivileges" = None
+        self, user_id: int | str, privileges: types.ChatPrivileges = None
     ) -> bool:
         """Bound method *promote_member* of :obj:`~hydrogram.types.Chat`.
 
@@ -982,8 +984,8 @@ class Chat(Object):
 
     async def get_member(
         self,
-        user_id: Union[int, str],
-    ) -> "types.ChatMember":
+        user_id: int | str,
+    ) -> types.ChatMember:
         """Bound method *get_member* of :obj:`~hydrogram.types.Chat`.
 
         Use as a shortcut for:
@@ -1007,8 +1009,8 @@ class Chat(Object):
         self,
         query: str = "",
         limit: int = 0,
-        filter: "enums.ChatMembersFilter" = enums.ChatMembersFilter.SEARCH,
-    ) -> Optional[AsyncGenerator["types.ChatMember", None]]:
+        filter: enums.ChatMembersFilter = enums.ChatMembersFilter.SEARCH,
+    ) -> AsyncGenerator[types.ChatMember, None] | None:
         """Bound method *get_members* of :obj:`~hydrogram.types.Chat`.
 
         Use as a shortcut for:
@@ -1047,7 +1049,7 @@ class Chat(Object):
 
     async def add_members(
         self,
-        user_ids: Union[Union[int, str], list[Union[int, str]]],
+        user_ids: int | str | list[int | str],
         forward_limit: int = 100,
     ) -> bool:
         """Bound method *add_members* of :obj:`~hydrogram.types.Chat`.

--- a/hydrogram/types/user_and_chats/chat_admin_with_invite_links.py
+++ b/hydrogram/types/user_and_chats/chat_admin_with_invite_links.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw, types
@@ -41,9 +41,9 @@ class ChatAdminWithInviteLinks(Object):
     def __init__(
         self,
         *,
-        admin: "types.User",
+        admin: types.User,
         chat_invite_links_count: int,
-        revoked_chat_invite_links_count: Optional[int] = None,
+        revoked_chat_invite_links_count: int | None = None,
     ):
         super().__init__()
 
@@ -53,10 +53,10 @@ class ChatAdminWithInviteLinks(Object):
 
     @staticmethod
     def _parse(
-        client: "hydrogram.Client",
-        admin: "raw.types.ChatAdminWithInvites",
-        users: Optional[dict[int, "raw.types.User"]] = None,
-    ) -> "ChatAdminWithInviteLinks":
+        client: hydrogram.Client,
+        admin: raw.types.ChatAdminWithInvites,
+        users: dict[int, raw.types.User] | None = None,
+    ) -> ChatAdminWithInviteLinks:
         return ChatAdminWithInviteLinks(
             admin=types.User._parse(client, users[admin.admin_id]),
             chat_invite_links_count=admin.invites_count,

--- a/hydrogram/types/user_and_chats/chat_event.py
+++ b/hydrogram/types/user_and_chats/chat_event.py
@@ -17,12 +17,16 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from datetime import datetime
-from typing import Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import hydrogram
 from hydrogram import enums, raw, types, utils
 from hydrogram.types.object import Object
+
+if TYPE_CHECKING:
+    from datetime import datetime
 
 
 class ChatEvent(Object):
@@ -149,46 +153,46 @@ class ChatEvent(Object):
         *,
         id: int,
         date: datetime,
-        user: "types.User",
+        user: types.User,
         action: str,
-        old_description: Optional[str] = None,
-        new_description: Optional[str] = None,
-        old_history_ttl: Optional[int] = None,
-        new_history_ttl: Optional[int] = None,
-        old_linked_chat: "types.Chat" = None,
-        new_linked_chat: "types.Chat" = None,
-        old_photo: "types.Photo" = None,
-        new_photo: "types.Photo" = None,
-        old_title: Optional[str] = None,
-        new_title: Optional[str] = None,
-        old_username: Optional[str] = None,
-        new_username: Optional[str] = None,
-        old_chat_permissions: "types.ChatPermissions" = None,
-        new_chat_permissions: "types.ChatPermissions" = None,
-        deleted_message: "types.Message" = None,
-        old_message: "types.Message" = None,
-        new_message: "types.Message" = None,
-        invited_member: "types.ChatMember" = None,
-        old_administrator_privileges: "types.ChatMember" = None,
-        new_administrator_privileges: "types.ChatMember" = None,
-        old_member_permissions: "types.ChatMember" = None,
-        new_member_permissions: "types.ChatMember" = None,
-        stopped_poll: "types.Message" = None,
-        invites_enabled: "types.ChatMember" = None,
-        history_hidden: Optional[bool] = None,
-        signatures_enabled: Optional[bool] = None,
-        old_slow_mode: Optional[int] = None,
-        new_slow_mode: Optional[int] = None,
-        pinned_message: "types.Message" = None,
-        unpinned_message: "types.Message" = None,
-        old_invite_link: "types.ChatInviteLink" = None,
-        new_invite_link: "types.ChatInviteLink" = None,
-        revoked_invite_link: "types.ChatInviteLink" = None,
-        deleted_invite_link: "types.ChatInviteLink" = None,
-        created_forum_topic: "types.ForumTopic" = None,
-        old_forum_topic: "types.ForumTopic" = None,
-        new_forum_topic: "types.ForumTopic" = None,
-        deleted_forum_topic: "types.ForumTopic" = None,
+        old_description: str | None = None,
+        new_description: str | None = None,
+        old_history_ttl: int | None = None,
+        new_history_ttl: int | None = None,
+        old_linked_chat: types.Chat = None,
+        new_linked_chat: types.Chat = None,
+        old_photo: types.Photo = None,
+        new_photo: types.Photo = None,
+        old_title: str | None = None,
+        new_title: str | None = None,
+        old_username: str | None = None,
+        new_username: str | None = None,
+        old_chat_permissions: types.ChatPermissions = None,
+        new_chat_permissions: types.ChatPermissions = None,
+        deleted_message: types.Message = None,
+        old_message: types.Message = None,
+        new_message: types.Message = None,
+        invited_member: types.ChatMember = None,
+        old_administrator_privileges: types.ChatMember = None,
+        new_administrator_privileges: types.ChatMember = None,
+        old_member_permissions: types.ChatMember = None,
+        new_member_permissions: types.ChatMember = None,
+        stopped_poll: types.Message = None,
+        invites_enabled: types.ChatMember = None,
+        history_hidden: bool | None = None,
+        signatures_enabled: bool | None = None,
+        old_slow_mode: int | None = None,
+        new_slow_mode: int | None = None,
+        pinned_message: types.Message = None,
+        unpinned_message: types.Message = None,
+        old_invite_link: types.ChatInviteLink = None,
+        new_invite_link: types.ChatInviteLink = None,
+        revoked_invite_link: types.ChatInviteLink = None,
+        deleted_invite_link: types.ChatInviteLink = None,
+        created_forum_topic: types.ForumTopic = None,
+        old_forum_topic: types.ForumTopic = None,
+        new_forum_topic: types.ForumTopic = None,
+        deleted_forum_topic: types.ForumTopic = None,
     ):
         super().__init__()
 
@@ -257,10 +261,10 @@ class ChatEvent(Object):
 
     @staticmethod
     async def _parse(
-        client: "hydrogram.Client",
-        event: "raw.base.ChannelAdminLogEvent",
-        users: list["raw.base.User"],
-        chats: list["raw.base.Chat"],
+        client: hydrogram.Client,
+        event: raw.base.ChannelAdminLogEvent,
+        users: list[raw.base.User],
+        chats: list[raw.base.Chat],
     ):
         users = {i.id: i for i in users}
         chats = {i.id: i for i in chats}
@@ -268,63 +272,63 @@ class ChatEvent(Object):
         user = types.User._parse(client, users[event.user_id])
         action = event.action
 
-        old_description: Optional[str] = None
-        new_description: Optional[str] = None
+        old_description: str | None = None
+        new_description: str | None = None
 
-        old_history_ttl: Optional[int] = None
-        new_history_ttl: Optional[int] = None
+        old_history_ttl: int | None = None
+        new_history_ttl: int | None = None
 
-        old_linked_chat: Optional[types.Chat] = None
-        new_linked_chat: Optional[types.Chat] = None
+        old_linked_chat: types.Chat | None = None
+        new_linked_chat: types.Chat | None = None
 
-        old_photo: Optional[types.Photo] = None
-        new_photo: Optional[types.Photo] = None
+        old_photo: types.Photo | None = None
+        new_photo: types.Photo | None = None
 
-        old_title: Optional[str] = None
-        new_title: Optional[str] = None
+        old_title: str | None = None
+        new_title: str | None = None
 
-        old_username: Optional[str] = None
-        new_username: Optional[str] = None
+        old_username: str | None = None
+        new_username: str | None = None
 
-        old_chat_permissions: Optional[types.ChatPermissions] = None
-        new_chat_permissions: Optional[types.ChatPermissions] = None
+        old_chat_permissions: types.ChatPermissions | None = None
+        new_chat_permissions: types.ChatPermissions | None = None
 
-        deleted_message: Optional[types.Message] = None
+        deleted_message: types.Message | None = None
 
-        old_message: Optional[types.Message] = None
-        new_message: Optional[types.Message] = None
+        old_message: types.Message | None = None
+        new_message: types.Message | None = None
 
-        invited_member: Optional[types.ChatMember] = None
+        invited_member: types.ChatMember | None = None
 
-        old_administrator_privileges: Optional[types.ChatMember] = None
-        new_administrator_privileges: Optional[types.ChatMember] = None
+        old_administrator_privileges: types.ChatMember | None = None
+        new_administrator_privileges: types.ChatMember | None = None
 
-        old_member_permissions: Optional[types.ChatMember] = None
-        new_member_permissions: Optional[types.ChatMember] = None
+        old_member_permissions: types.ChatMember | None = None
+        new_member_permissions: types.ChatMember | None = None
 
-        stopped_poll: Optional[types.Message] = None
+        stopped_poll: types.Message | None = None
 
-        invites_enabled: Optional[bool] = None
+        invites_enabled: bool | None = None
 
-        history_hidden: Optional[bool] = None
+        history_hidden: bool | None = None
 
-        signatures_enabled: Optional[bool] = None
+        signatures_enabled: bool | None = None
 
-        old_slow_mode: Optional[int] = None
-        new_slow_mode: Optional[int] = None
+        old_slow_mode: int | None = None
+        new_slow_mode: int | None = None
 
-        pinned_message: Optional[types.Message] = None
-        unpinned_message: Optional[types.Message] = None
+        pinned_message: types.Message | None = None
+        unpinned_message: types.Message | None = None
 
-        old_invite_link: Optional[types.ChatInviteLink] = None
-        new_invite_link: Optional[types.ChatInviteLink] = None
-        revoked_invite_link: Optional[types.ChatInviteLink] = None
-        deleted_invite_link: Optional[types.ChatInviteLink] = None
+        old_invite_link: types.ChatInviteLink | None = None
+        new_invite_link: types.ChatInviteLink | None = None
+        revoked_invite_link: types.ChatInviteLink | None = None
+        deleted_invite_link: types.ChatInviteLink | None = None
 
-        created_forum_topic: Optional[types.ForumTopic] = None
-        old_forum_topic: Optional[types.ForumTopic] = None
-        new_forum_topic: Optional[types.ForumTopic] = None
-        deleted_forum_topic: Optional[types.ForumTopic] = None
+        created_forum_topic: types.ForumTopic | None = None
+        old_forum_topic: types.ForumTopic | None = None
+        new_forum_topic: types.ForumTopic | None = None
+        deleted_forum_topic: types.ForumTopic | None = None
 
         if isinstance(action, raw.types.ChannelAdminLogEventActionChangeAbout):
             old_description = action.prev_value

--- a/hydrogram/types/user_and_chats/chat_invite_link.py
+++ b/hydrogram/types/user_and_chats/chat_invite_link.py
@@ -17,12 +17,16 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from datetime import datetime
-from typing import Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import hydrogram
 from hydrogram import raw, types, utils
 from hydrogram.types.object import Object
+
+if TYPE_CHECKING:
+    from datetime import datetime
 
 
 class ChatInviteLink(Object):
@@ -73,16 +77,16 @@ class ChatInviteLink(Object):
         *,
         invite_link: str,
         date: datetime,
-        is_primary: Optional[bool] = None,
-        is_revoked: Optional[bool] = None,
-        creator: "types.User" = None,
-        name: Optional[str] = None,
-        creates_join_request: Optional[bool] = None,
-        start_date: Optional[datetime] = None,
-        expire_date: Optional[datetime] = None,
-        member_limit: Optional[int] = None,
-        member_count: Optional[int] = None,
-        pending_join_request_count: Optional[int] = None,
+        is_primary: bool | None = None,
+        is_revoked: bool | None = None,
+        creator: types.User = None,
+        name: str | None = None,
+        creates_join_request: bool | None = None,
+        start_date: datetime | None = None,
+        expire_date: datetime | None = None,
+        member_limit: int | None = None,
+        member_count: int | None = None,
+        pending_join_request_count: int | None = None,
     ):
         super().__init__()
 
@@ -101,10 +105,10 @@ class ChatInviteLink(Object):
 
     @staticmethod
     def _parse(
-        client: "hydrogram.Client",
-        invite: "raw.base.ExportedChatInvite",
-        users: Optional[dict[int, "raw.types.User"]] = None,
-    ) -> Optional["ChatInviteLink"]:
+        client: hydrogram.Client,
+        invite: raw.base.ExportedChatInvite,
+        users: dict[int, raw.types.User] | None = None,
+    ) -> ChatInviteLink | None:
         if not isinstance(invite, raw.types.ChatInviteExported):
             return None
 

--- a/hydrogram/types/user_and_chats/chat_join_request.py
+++ b/hydrogram/types/user_and_chats/chat_join_request.py
@@ -17,13 +17,17 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from datetime import datetime
-from typing import Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import hydrogram
 from hydrogram import raw, types, utils
 from hydrogram.types.object import Object
 from hydrogram.types.update import Update
+
+if TYPE_CHECKING:
+    from datetime import datetime
 
 
 class ChatJoinRequest(Object, Update):
@@ -49,12 +53,12 @@ class ChatJoinRequest(Object, Update):
     def __init__(
         self,
         *,
-        client: "hydrogram.Client" = None,
-        chat: "types.Chat",
-        from_user: "types.User",
+        client: hydrogram.Client = None,
+        chat: types.Chat,
+        from_user: types.User,
         date: datetime,
-        bio: Optional[str] = None,
-        invite_link: "types.ChatInviteLink" = None,
+        bio: str | None = None,
+        invite_link: types.ChatInviteLink = None,
     ):
         super().__init__(client)
 
@@ -66,11 +70,11 @@ class ChatJoinRequest(Object, Update):
 
     @staticmethod
     def _parse(
-        client: "hydrogram.Client",
-        update: "raw.types.UpdateBotChatInviteRequester",
-        users: dict[int, "raw.types.User"],
-        chats: dict[int, "raw.types.Chat"],
-    ) -> "ChatJoinRequest":
+        client: hydrogram.Client,
+        update: raw.types.UpdateBotChatInviteRequester,
+        users: dict[int, raw.types.User],
+        chats: dict[int, raw.types.Chat],
+    ) -> ChatJoinRequest:
         chat_id = utils.get_raw_peer_id(update.peer)
 
         return ChatJoinRequest(

--- a/hydrogram/types/user_and_chats/chat_joiner.py
+++ b/hydrogram/types/user_and_chats/chat_joiner.py
@@ -17,12 +17,16 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from datetime import datetime
-from typing import Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import hydrogram
 from hydrogram import raw, types, utils
 from hydrogram.types.object import Object
+
+if TYPE_CHECKING:
+    from datetime import datetime
 
 
 class ChatJoiner(Object):
@@ -48,12 +52,12 @@ class ChatJoiner(Object):
     def __init__(
         self,
         *,
-        client: "hydrogram.Client",
-        user: "types.User",
-        date: Optional[datetime] = None,
-        bio: Optional[str] = None,
-        pending: Optional[bool] = None,
-        approved_by: "types.User" = None,
+        client: hydrogram.Client,
+        user: types.User,
+        date: datetime | None = None,
+        bio: str | None = None,
+        pending: bool | None = None,
+        approved_by: types.User = None,
     ):
         super().__init__(client)
 
@@ -65,10 +69,10 @@ class ChatJoiner(Object):
 
     @staticmethod
     def _parse(
-        client: "hydrogram.Client",
-        joiner: "raw.base.ChatInviteImporter",
-        users: dict[int, "raw.base.User"],
-    ) -> "ChatJoiner":
+        client: hydrogram.Client,
+        joiner: raw.base.ChatInviteImporter,
+        users: dict[int, raw.base.User],
+    ) -> ChatJoiner:
         return ChatJoiner(
             user=types.User._parse(client, users[joiner.user_id]),
             date=utils.timestamp_to_datetime(joiner.date),

--- a/hydrogram/types/user_and_chats/chat_member.py
+++ b/hydrogram/types/user_and_chats/chat_member.py
@@ -17,12 +17,16 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from datetime import datetime
-from typing import Optional, Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import hydrogram
 from hydrogram import enums, raw, types, utils
 from hydrogram.types.object import Object
+
+if TYPE_CHECKING:
+    from datetime import datetime
 
 
 class ChatMember(Object):
@@ -76,20 +80,20 @@ class ChatMember(Object):
     def __init__(
         self,
         *,
-        client: "hydrogram.Client" = None,
-        status: "enums.ChatMemberStatus",
-        user: "types.User" = None,
-        chat: "types.Chat" = None,
-        custom_title: Optional[str] = None,
-        until_date: Optional[datetime] = None,
-        joined_date: Optional[datetime] = None,
-        invited_by: "types.User" = None,
-        promoted_by: "types.User" = None,
-        restricted_by: "types.User" = None,
-        is_member: Optional[bool] = None,
-        can_be_edited: Optional[bool] = None,
-        permissions: "types.ChatPermissions" = None,
-        privileges: "types.ChatPrivileges" = None,
+        client: hydrogram.Client = None,
+        status: enums.ChatMemberStatus,
+        user: types.User = None,
+        chat: types.Chat = None,
+        custom_title: str | None = None,
+        until_date: datetime | None = None,
+        joined_date: datetime | None = None,
+        invited_by: types.User = None,
+        promoted_by: types.User = None,
+        restricted_by: types.User = None,
+        is_member: bool | None = None,
+        can_be_edited: bool | None = None,
+        permissions: types.ChatPermissions = None,
+        privileges: types.ChatPrivileges = None,
     ):
         super().__init__(client)
 
@@ -109,11 +113,11 @@ class ChatMember(Object):
 
     @staticmethod
     def _parse(
-        client: "hydrogram.Client",
-        member: Union["raw.base.ChatParticipant", "raw.base.ChannelParticipant"],
-        users: dict[int, "raw.base.User"],
-        chats: dict[int, "raw.base.Chat"],
-    ) -> "ChatMember":
+        client: hydrogram.Client,
+        member: raw.base.ChatParticipant | raw.base.ChannelParticipant,
+        users: dict[int, raw.base.User],
+        chats: dict[int, raw.base.Chat],
+    ) -> ChatMember:
         # Chat participants
         if isinstance(member, raw.types.ChatParticipant):
             return ChatMember(

--- a/hydrogram/types/user_and_chats/chat_permissions.py
+++ b/hydrogram/types/user_and_chats/chat_permissions.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
+from __future__ import annotations
 
 from hydrogram import raw
 from hydrogram.types.object import Object
@@ -65,17 +65,16 @@ class ChatPermissions(Object):
     def __init__(
         self,
         *,
-        can_send_messages: Optional[bool] = None,  # Text, contacts, locations and venues
-        can_send_media_messages: Optional[
-            bool
-        ] = None,  # Audio files, documents, photos, videos, video notes and voice notes
-        can_send_other_messages: Optional[bool] = None,  # Stickers, animations, games, inline bots
-        can_send_polls: Optional[bool] = None,
-        can_add_web_page_previews: Optional[bool] = None,
-        can_change_info: Optional[bool] = None,
-        can_invite_users: Optional[bool] = None,
-        can_pin_messages: Optional[bool] = None,
-        can_manage_topics: Optional[bool] = None,
+        can_send_messages: bool | None = None,  # Text, contacts, locations and venues
+        can_send_media_messages: bool
+        | None = None,  # Audio files, documents, photos, videos, video notes and voice notes
+        can_send_other_messages: bool | None = None,  # Stickers, animations, games, inline bots
+        can_send_polls: bool | None = None,
+        can_add_web_page_previews: bool | None = None,
+        can_change_info: bool | None = None,
+        can_invite_users: bool | None = None,
+        can_pin_messages: bool | None = None,
+        can_manage_topics: bool | None = None,
     ):
         super().__init__(None)
 
@@ -90,7 +89,7 @@ class ChatPermissions(Object):
         self.can_manage_topics = can_manage_topics
 
     @staticmethod
-    def _parse(denied_permissions: "raw.base.ChatBannedRights") -> "ChatPermissions":
+    def _parse(denied_permissions: raw.base.ChatBannedRights) -> ChatPermissions:
         if isinstance(denied_permissions, raw.types.ChatBannedRights):
             return ChatPermissions(
                 can_send_messages=not denied_permissions.send_messages,

--- a/hydrogram/types/user_and_chats/chat_preview.py
+++ b/hydrogram/types/user_and_chats/chat_preview.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw, types
@@ -47,12 +47,12 @@ class ChatPreview(Object):
     def __init__(
         self,
         *,
-        client: "hydrogram.Client" = None,
+        client: hydrogram.Client = None,
         title: str,
         type: str,
         members_count: int,
-        photo: "types.Photo" = None,
-        members: Optional[list["types.User"]] = None,
+        photo: types.Photo = None,
+        members: list[types.User] | None = None,
     ):
         super().__init__(client)
 
@@ -63,7 +63,7 @@ class ChatPreview(Object):
         self.members = members
 
     @staticmethod
-    def _parse(client, chat_invite: "raw.types.ChatInvite") -> "ChatPreview":
+    def _parse(client, chat_invite: raw.types.ChatInvite) -> ChatPreview:
         return ChatPreview(
             title=chat_invite.title,
             type=(

--- a/hydrogram/types/user_and_chats/chat_privileges.py
+++ b/hydrogram/types/user_and_chats/chat_privileges.py
@@ -17,8 +17,12 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from hydrogram import raw
+from typing import TYPE_CHECKING
+
 from hydrogram.types.object import Object
+
+if TYPE_CHECKING:
+    from hydrogram import raw
 
 
 class ChatPrivileges(Object):

--- a/hydrogram/types/user_and_chats/chat_reactions.py
+++ b/hydrogram/types/user_and_chats/chat_reactions.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw, types
@@ -40,10 +40,10 @@ class ChatReactions(Object):
     def __init__(
         self,
         *,
-        client: "hydrogram.Client" = None,
-        all_are_enabled: Optional[bool] = None,
-        allow_custom_emoji: Optional[bool] = None,
-        reactions: Optional[list["types.Reaction"]] = None,
+        client: hydrogram.Client = None,
+        all_are_enabled: bool | None = None,
+        allow_custom_emoji: bool | None = None,
+        reactions: list[types.Reaction] | None = None,
     ):
         super().__init__(client)
 
@@ -52,7 +52,7 @@ class ChatReactions(Object):
         self.reactions = reactions
 
     @staticmethod
-    def _parse(client, chat_reactions: "raw.base.ChatReactions") -> Optional["ChatReactions"]:
+    def _parse(client, chat_reactions: raw.base.ChatReactions) -> ChatReactions | None:
         if isinstance(chat_reactions, raw.types.ChatReactionsAll):
             return ChatReactions(
                 client=client,

--- a/hydrogram/types/user_and_chats/emoji_status.py
+++ b/hydrogram/types/user_and_chats/emoji_status.py
@@ -17,12 +17,16 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from datetime import datetime
-from typing import Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import hydrogram
 from hydrogram import raw, utils
 from hydrogram.types.object import Object
+
+if TYPE_CHECKING:
+    from datetime import datetime
 
 
 class EmojiStatus(Object):
@@ -39,9 +43,9 @@ class EmojiStatus(Object):
     def __init__(
         self,
         *,
-        client: "hydrogram.Client" = None,
+        client: hydrogram.Client = None,
         custom_emoji_id: int,
-        until_date: Optional[datetime] = None,
+        until_date: datetime | None = None,
     ):
         super().__init__(client)
 
@@ -49,7 +53,7 @@ class EmojiStatus(Object):
         self.until_date = until_date
 
     @staticmethod
-    def _parse(client, emoji_status: "raw.base.EmojiStatus") -> Optional["EmojiStatus"]:
+    def _parse(client, emoji_status: raw.base.EmojiStatus) -> EmojiStatus | None:
         if isinstance(emoji_status, raw.types.EmojiStatus):
             return EmojiStatus(client=client, custom_emoji_id=emoji_status.document_id)
 

--- a/hydrogram/types/user_and_chats/forum_topic.py
+++ b/hydrogram/types/user_and_chats/forum_topic.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional, Union
+from __future__ import annotations
 
 from hydrogram import raw, types
 from hydrogram.types.object import Object
@@ -92,13 +92,13 @@ class ForumTopic(Object):
         unread_count: int,
         unread_mentions_count: int,
         unread_reactions_count: int,
-        from_id: Union["types.PeerChannel", "types.PeerUser"],
+        from_id: types.PeerChannel | types.PeerUser,
         # notify_settings: "types.PeerNotifySettings", //todo
-        my: Optional[bool] = None,
-        closed: Optional[bool] = None,
-        pinned: Optional[bool] = None,
-        short: Optional[bool] = None,
-        icon_emoji_id: Optional[int] = None,
+        my: bool | None = None,
+        closed: bool | None = None,
+        pinned: bool | None = None,
+        short: bool | None = None,
+        icon_emoji_id: int | None = None,
         # draft: "types.DraftMessage" = None //todo
     ):
         super().__init__()
@@ -123,7 +123,7 @@ class ForumTopic(Object):
         # self.draft = draft //todo
 
     @staticmethod
-    def _parse(forum_topic: "raw.types.forum_topic") -> "ForumTopic":
+    def _parse(forum_topic: raw.types.forum_topic) -> ForumTopic:
         from_id = forum_topic.from_id
         if isinstance(from_id, raw.types.PeerChannel):
             peer = types.PeerChannel._parse(from_id)

--- a/hydrogram/types/user_and_chats/forum_topic_created.py
+++ b/hydrogram/types/user_and_chats/forum_topic_created.py
@@ -16,10 +16,14 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
+from __future__ import annotations
 
-from hydrogram import raw
+from typing import TYPE_CHECKING
+
 from hydrogram.types.object import Object
+
+if TYPE_CHECKING:
+    from hydrogram import raw
 
 
 class ForumTopicCreated(Object):
@@ -37,7 +41,7 @@ class ForumTopicCreated(Object):
             Unique identifier of the custom emoji shown as the topic icon
     """
 
-    def __init__(self, *, title: str, icon_color: int, icon_emoji_id: Optional[int] = None):
+    def __init__(self, *, title: str, icon_color: int, icon_emoji_id: int | None = None):
         super().__init__()
 
         self.title = title
@@ -45,7 +49,7 @@ class ForumTopicCreated(Object):
         self.icon_emoji_id = icon_emoji_id
 
     @staticmethod
-    def _parse(action: "raw.types.MessageActionTopicCreate") -> "ForumTopicCreated":
+    def _parse(action: raw.types.MessageActionTopicCreate) -> ForumTopicCreated:
         return ForumTopicCreated(
             title=getattr(action, "title", None),
             icon_color=getattr(action, "icon_color", None),

--- a/hydrogram/types/user_and_chats/forum_topic_edited.py
+++ b/hydrogram/types/user_and_chats/forum_topic_edited.py
@@ -16,10 +16,14 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
+from __future__ import annotations
 
-from hydrogram import raw
+from typing import TYPE_CHECKING
+
 from hydrogram.types.object import Object
+
+if TYPE_CHECKING:
+    from hydrogram import raw
 
 
 class ForumTopicEdited(Object):
@@ -40,9 +44,9 @@ class ForumTopicEdited(Object):
     def __init__(
         self,
         *,
-        title: Optional[str] = None,
-        icon_color: Optional[int] = None,
-        icon_emoji_id: Optional[str] = None,
+        title: str | None = None,
+        icon_color: int | None = None,
+        icon_emoji_id: str | None = None,
     ):
         super().__init__()
 
@@ -51,7 +55,7 @@ class ForumTopicEdited(Object):
         self.icon_emoji_id = icon_emoji_id
 
     @staticmethod
-    def _parse(action: "raw.types.MessageActionTopicEdit") -> "ForumTopicEdited":
+    def _parse(action: raw.types.MessageActionTopicEdit) -> ForumTopicEdited:
         return ForumTopicEdited(
             title=getattr(action, "title", None),
             icon_color=getattr(action, "icon_color", None),

--- a/hydrogram/types/user_and_chats/peer_channel.py
+++ b/hydrogram/types/user_and_chats/peer_channel.py
@@ -16,8 +16,12 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from hydrogram import raw
+from typing import TYPE_CHECKING
+
 from hydrogram.types.object import Object
+
+if TYPE_CHECKING:
+    from hydrogram import raw
 
 
 class PeerChannel(Object):

--- a/hydrogram/types/user_and_chats/peer_user.py
+++ b/hydrogram/types/user_and_chats/peer_user.py
@@ -16,8 +16,12 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from hydrogram import raw
+from typing import TYPE_CHECKING
+
 from hydrogram.types.object import Object
+
+if TYPE_CHECKING:
+    from hydrogram import raw
 
 
 class PeerUser(Object):

--- a/hydrogram/types/user_and_chats/restriction.py
+++ b/hydrogram/types/user_and_chats/restriction.py
@@ -17,8 +17,12 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from hydrogram import raw
+from typing import TYPE_CHECKING
+
 from hydrogram.types.object import Object
+
+if TYPE_CHECKING:
+    from hydrogram import raw
 
 
 class Restriction(Object):

--- a/hydrogram/types/user_and_chats/user.py
+++ b/hydrogram/types/user_and_chats/user.py
@@ -17,15 +17,19 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import html
-from datetime import datetime
-from typing import Optional, Union
+from typing import TYPE_CHECKING
 
 import hydrogram
 from hydrogram import enums, filters, raw, types, utils
 from hydrogram.types.object import Object
 from hydrogram.types.pyromod import ListenerTypes
 from hydrogram.types.update import Update
+
+if TYPE_CHECKING:
+    from datetime import datetime
 
 
 class Link(str):
@@ -48,7 +52,7 @@ class Link(str):
     def __new__(cls, url, text, style):
         return str.__new__(cls, Link.format(url, text, style))
 
-    def __call__(self, other: Optional[str] = None, *, style: Optional[str] = None):
+    def __call__(self, other: str | None = None, *, style: str | None = None):
         return Link.format(self.url, other or self.text, style or self.style)
 
     def __str__(self):
@@ -155,33 +159,33 @@ class User(Object, Update):
     def __init__(
         self,
         *,
-        client: "hydrogram.Client" = None,
+        client: hydrogram.Client = None,
         id: int,
-        is_self: Optional[bool] = None,
-        is_contact: Optional[bool] = None,
-        is_mutual_contact: Optional[bool] = None,
-        is_deleted: Optional[bool] = None,
-        is_bot: Optional[bool] = None,
-        is_verified: Optional[bool] = None,
-        is_restricted: Optional[bool] = None,
-        is_scam: Optional[bool] = None,
-        is_fake: Optional[bool] = None,
-        is_support: Optional[bool] = None,
-        is_premium: Optional[bool] = None,
-        first_name: Optional[str] = None,
-        last_name: Optional[str] = None,
-        status: "enums.UserStatus" = None,
-        last_online_date: Optional[datetime] = None,
-        next_offline_date: Optional[datetime] = None,
-        username: Optional[str] = None,
-        active_usernames: Optional[str] = None,
-        usernames: Optional[list["types.Username"]] = None,
-        language_code: Optional[str] = None,
-        emoji_status: Optional["types.EmojiStatus"] = None,
-        dc_id: Optional[int] = None,
-        phone_number: Optional[str] = None,
-        photo: "types.ChatPhoto" = None,
-        restrictions: Optional[list["types.Restriction"]] = None,
+        is_self: bool | None = None,
+        is_contact: bool | None = None,
+        is_mutual_contact: bool | None = None,
+        is_deleted: bool | None = None,
+        is_bot: bool | None = None,
+        is_verified: bool | None = None,
+        is_restricted: bool | None = None,
+        is_scam: bool | None = None,
+        is_fake: bool | None = None,
+        is_support: bool | None = None,
+        is_premium: bool | None = None,
+        first_name: str | None = None,
+        last_name: str | None = None,
+        status: enums.UserStatus = None,
+        last_online_date: datetime | None = None,
+        next_offline_date: datetime | None = None,
+        username: str | None = None,
+        active_usernames: str | None = None,
+        usernames: list[types.Username] | None = None,
+        language_code: str | None = None,
+        emoji_status: types.EmojiStatus | None = None,
+        dc_id: int | None = None,
+        phone_number: str | None = None,
+        photo: types.ChatPhoto = None,
+        restrictions: list[types.Restriction] | None = None,
     ):
         super().__init__(client)
 
@@ -225,7 +229,7 @@ class User(Object, Update):
         )
 
     @staticmethod
-    def _parse(client, user: "raw.base.User") -> Optional["User"]:
+    def _parse(client, user: raw.base.User) -> User | None:
         if user is None or isinstance(user, raw.types.UserEmpty):
             return None
 
@@ -262,7 +266,7 @@ class User(Object, Update):
         )
 
     @staticmethod
-    def _parse_status(user_status: "raw.base.UserStatus", is_bot: bool = False):
+    def _parse_status(user_status: raw.base.UserStatus, is_bot: bool = False):
         if isinstance(user_status, raw.types.UserStatusOnline):
             status, date = enums.UserStatus.ONLINE, user_status.expires
         elif isinstance(user_status, raw.types.UserStatusOffline):
@@ -295,7 +299,7 @@ class User(Object, Update):
         }
 
     @staticmethod
-    def _parse_user_status(client, user_status: "raw.types.UpdateUserStatus"):
+    def _parse_user_status(client, user_status: raw.types.UpdateUserStatus):
         return User(
             id=user_status.user_id,
             **User._parse_status(user_status.status),
@@ -304,13 +308,13 @@ class User(Object, Update):
 
     def listen(
         self,
-        filters: Optional["filters.Filter"] = None,
+        filters: filters.Filter | None = None,
         listener_type: ListenerTypes = ListenerTypes.MESSAGE,
-        timeout: Optional[int] = None,
+        timeout: int | None = None,
         unallowed_click_alert: bool = True,
-        chat_id: Optional[Union[int, str, list[Union[int, str]]]] = None,
-        message_id: Optional[Union[int, list[int]]] = None,
-        inline_message_id: Optional[Union[str, list[str]]] = None,
+        chat_id: int | str | list[int | str] | None = None,
+        message_id: int | list[int] | None = None,
+        inline_message_id: str | list[str] | None = None,
     ):
         """
         Bound method *listen* of :obj:`~hydrogram.types.User`.
@@ -365,12 +369,12 @@ class User(Object, Update):
     def ask(
         self,
         text: str,
-        filters: Optional["filters.Filter"] = None,
+        filters: filters.Filter | None = None,
         listener_type: ListenerTypes = ListenerTypes.MESSAGE,
-        timeout: Optional[int] = None,
+        timeout: int | None = None,
         unallowed_click_alert: bool = True,
-        message_id: Optional[Union[int, list[int]]] = None,
-        inline_message_id: Optional[Union[str, list[str]]] = None,
+        message_id: int | list[int] | None = None,
+        inline_message_id: str | list[str] | None = None,
         *args,
         **kwargs,
     ):
@@ -436,9 +440,9 @@ class User(Object, Update):
     def stop_listening(
         self,
         listener_type: ListenerTypes = ListenerTypes.MESSAGE,
-        chat_id: Optional[Union[int, str, list[Union[int, str]]]] = None,
-        message_id: Optional[Union[int, list[int]]] = None,
-        inline_message_id: Optional[Union[str, list[str]]] = None,
+        chat_id: int | str | list[int | str] | None = None,
+        message_id: int | list[int] | None = None,
+        inline_message_id: str | list[str] | None = None,
     ):
         """
         Stops listening for messages from the user. Calls Client.stop_listening() with the user_id set to the user's id.

--- a/hydrogram/types/user_and_chats/username.py
+++ b/hydrogram/types/user_and_chats/username.py
@@ -16,10 +16,14 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
+from __future__ import annotations
 
-from hydrogram import raw
+from typing import TYPE_CHECKING
+
 from hydrogram.types.object import Object
+
+if TYPE_CHECKING:
+    from hydrogram import raw
 
 
 class Username(Object):
@@ -37,9 +41,7 @@ class Username(Object):
 
     """
 
-    def __init__(
-        self, *, username: str, editable: Optional[bool] = None, active: Optional[bool] = None
-    ):
+    def __init__(self, *, username: str, editable: bool | None = None, active: bool | None = None):
         super().__init__(None)
 
         self.username = username
@@ -47,7 +49,7 @@ class Username(Object):
         self.active = active
 
     @staticmethod
-    def _parse(username: "raw.types.Username") -> "Username":
+    def _parse(username: raw.types.Username) -> Username:
         return Username(
             username=username.username, editable=username.editable, active=username.active
         )

--- a/hydrogram/types/user_and_chats/video_chat_ended.py
+++ b/hydrogram/types/user_and_chats/video_chat_ended.py
@@ -17,8 +17,12 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from hydrogram import raw
+from typing import TYPE_CHECKING
+
 from hydrogram.types.object import Object
+
+if TYPE_CHECKING:
+    from hydrogram import raw
 
 
 class VideoChatEnded(Object):

--- a/hydrogram/utils.py
+++ b/hydrogram/utils.py
@@ -17,6 +17,8 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import asyncio
 import base64
 import functools
@@ -27,7 +29,6 @@ from concurrent.futures.thread import ThreadPoolExecutor
 from datetime import datetime, timezone
 from getpass import getpass
 from types import SimpleNamespace
-from typing import Optional, Union
 
 import hydrogram
 from hydrogram import enums, raw, types
@@ -50,8 +51,8 @@ async def ainput(prompt: str = "", *, hide: bool = False):
 
 
 def get_input_media_from_file_id(
-    file_id: str, expected_file_type: FileType = None, ttl_seconds: Optional[int] = None
-) -> Union["raw.types.InputMediaPhoto", "raw.types.InputMediaDocument"]:
+    file_id: str, expected_file_type: FileType = None, ttl_seconds: int | None = None
+) -> raw.types.InputMediaPhoto | raw.types.InputMediaDocument:
     try:
         decoded = FileId.decode(file_id)
     except Exception as e:
@@ -94,8 +95,8 @@ def get_input_media_from_file_id(
 
 
 async def parse_messages(
-    client, messages: "raw.types.messages.Messages", replies: int = 1
-) -> list["types.Message"]:
+    client, messages: raw.types.messages.Messages, replies: int = 1
+) -> list[types.Message]:
     users = {i.id: i for i in messages.users}
     chats = {i.id: i for i in messages.chats}
     topics = {i.id: i for i in messages.topics} if hasattr(messages, "topics") else None
@@ -137,7 +138,7 @@ async def parse_messages(
     return types.List(parsed_messages)
 
 
-def parse_deleted_messages(client, update) -> list["types.Message"]:
+def parse_deleted_messages(client, update) -> list[types.Message]:
     messages = update.messages
     channel_id = getattr(update, "channel_id", None)
 
@@ -158,7 +159,7 @@ def parse_deleted_messages(client, update) -> list["types.Message"]:
     return types.List(parsed_messages)
 
 
-def pack_inline_message_id(msg_id: "raw.base.InputBotInlineMessageID"):
+def pack_inline_message_id(msg_id: raw.base.InputBotInlineMessageID):
     if isinstance(msg_id, raw.types.InputBotInlineMessageID):
         inline_message_id_packed = struct.pack("<iqq", msg_id.dc_id, msg_id.id, msg_id.access_hash)
     else:
@@ -169,7 +170,7 @@ def pack_inline_message_id(msg_id: "raw.base.InputBotInlineMessageID"):
     return base64.urlsafe_b64encode(inline_message_id_packed).decode().rstrip("=")
 
 
-def unpack_inline_message_id(inline_message_id: str) -> "raw.base.InputBotInlineMessageID":
+def unpack_inline_message_id(inline_message_id: str) -> raw.base.InputBotInlineMessageID:
     padded = inline_message_id + "=" * (-len(inline_message_id) % 4)
     decoded = base64.urlsafe_b64decode(padded)
 
@@ -197,7 +198,7 @@ MAX_USER_ID_OLD = 2147483647
 MAX_USER_ID = 999999999999
 
 
-def get_raw_peer_id(peer: raw.base.Peer) -> Optional[int]:
+def get_raw_peer_id(peer: raw.base.Peer) -> int | None:
     """Get the raw peer id from a Peer object"""
     if isinstance(peer, raw.types.PeerUser):
         return peer.user_id
@@ -327,11 +328,11 @@ def compute_password_check(
 
 
 async def parse_text_entities(
-    client: "hydrogram.Client",
+    client: hydrogram.Client,
     text: str,
     parse_mode: enums.ParseMode,
-    entities: list["types.MessageEntity"],
-) -> dict[str, Union[str, list[raw.base.MessageEntity]]]:
+    entities: list[types.MessageEntity],
+) -> dict[str, str | list[raw.base.MessageEntity]]:
     if entities:
         # Inject the client instance because parsing user mentions requires it
         for entity in entities:
@@ -348,11 +349,11 @@ def zero_datetime() -> datetime:
     return datetime.fromtimestamp(0, timezone.utc)
 
 
-def timestamp_to_datetime(ts: Optional[int]) -> Optional[datetime]:
+def timestamp_to_datetime(ts: int | None) -> datetime | None:
     return datetime.fromtimestamp(ts) if ts else None
 
 
-def datetime_to_timestamp(dt: Optional[datetime]) -> Optional[int]:
+def datetime_to_timestamp(dt: datetime | None) -> int | None:
     return int(dt.timestamp()) if dt else None
 
 

--- a/news/24.feature.rst
+++ b/news/24.feature.rst
@@ -1,0 +1,1 @@
+Added the `from __future__ import annotations` statement to the codebase in order to simplify the usage of the typing module. This statement allows for the use of forward references in type hints, which can improve code readability and maintainability.

--- a/news/24.misc.rst
+++ b/news/24.misc.rst
@@ -1,0 +1,1 @@
+Added `if TYPE_CHECKING` to import modules for type checking only when needed. This flag avoids importing modules that are not needed for runtime execution. This change reduces the number of imports in the module and improves the performance of the code.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ build-backend = "hatchling.build"
 [tool.rye]
 managed = true
 dev-dependencies = [
-    "ruff>=0.4.4",
+    "ruff>=0.4.5",
     "pytest>=7.4.3",
     "pytest-asyncio>=0.23.2",
     "pytest-cov>=4.1.0",
@@ -95,7 +95,6 @@ package = "hydrogram"
 [tool.ruff]
 line-length = 99
 target-version = "py39"
-preview = true
 
 [tool.ruff.lint]
 select = [
@@ -113,14 +112,18 @@ select = [
     "RUF",  # ruff
     "G",    # flake8-logging-format
     "TID",  # flake8-tidy-imports
+    "TCH",  # flake8-type-checking
+    "FA",   # flake8-future-annotations
 ]
 ignore = ["RUF001", "RUF002", "RUF003", "E203", "PERF203"]
+preview = true
 
 [tool.ruff.lint.isort]
 known-first-party = ["hydrogram"]
 
 [tool.ruff.format]
 docstring-code-format = true
+preview = true
 
 [tool.towncrier]
 package = "hydrogram"

--- a/tests/filters/__init__.py
+++ b/tests/filters/__init__.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
+from __future__ import annotations
 
 
 class Client:
@@ -29,12 +29,12 @@ class Client:
 
 
 class User:
-    def __init__(self, username: Optional[str] = None):
+    def __init__(self, username: str | None = None):
         self.username = username
 
 
 class Message:
-    def __init__(self, text: Optional[str] = None, caption: Optional[str] = None):
+    def __init__(self, text: str | None = None, caption: str | None = None):
         self.text = text
         self.caption = caption
         self.command = None


### PR DESCRIPTION
## Description

This pull request adds the `from __future__ import annotations` statement to the codebase in order to simplify the usage of the `typing` module. This statement allows for the use of forward references in type hints, which can improve code readability and maintainability.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
