### PR TITLE
Fix for: Invalid peer type: group

### DIFF
--- a/hydrogram/storage/sqlite_storage.py
+++ b/hydrogram/storage/sqlite_storage.py
@@ -78,7 +78,7 @@ END;
 def get_input_peer(peer_id: int, access_hash: int, peer_type: str) -> InputPeer:
     if peer_type in {"user", "bot"}:
         return raw.types.InputPeerUser(user_id=peer_id, access_hash=access_hash)
-    if peer_type == ChatType.GROUP:
+    if peer_type == "group":
         return raw.types.InputPeerChat(chat_id=-peer_id)
     if peer_type in {"channel", "supergroup"}:
         return raw.types.InputPeerChannel(


### PR DESCRIPTION
If this change is not made, the bot does not work in groups and gives the following error:

```python
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/hydrogram/dispatcher.py", line 220, in _handle_update
    await self._execute_callback(handler, parsed_update)
  File "/usr/local/lib/python3.10/dist-packages/hydrogram/dispatcher.py", line 232, in _execute_callback
    await handler.callback(self.client, *args)
  File "/usr/local/lib/python3.10/dist-packages/hydrogram/handlers/message_handler.py", line 170, in resolve_future_or_callback
    await self.original_callback(client, message, *args)
  File "/root/my_bot/main.py", line 3028, in baslat
    await app.send_message(chat_id, "Hello", reply_markup=keyboard, reply_to_message_id = reply_msg)
  File "/usr/local/lib/python3.10/dist-packages/hydrogram/methods/messages/send_message.py", line 139, in send_message
    peer=await self.resolve_peer(chat_id),
  File "/usr/local/lib/python3.10/dist-packages/hydrogram/methods/advanced/resolve_peer.py", line 62, in resolve_peer
    return await self.storage.get_peer_by_id(peer_id)
  File "/usr/local/lib/python3.10/dist-packages/hydrogram/storage/sqlite_storage.py", line 227, in get_peer_by_id
    return get_input_peer(*r)
  File "/usr/local/lib/python3.10/dist-packages/hydrogram/storage/sqlite_storage.py", line 87, in get_input_peer
    raise ValueError(f"Invalid peer type: {peer_type}")
```