### PR TITLE
feat(filters): allow the use of filters.{private,group,channel} in callback queries

### DIFF
--- a/hydrogram/filters.py
+++ b/hydrogram/filters.py
@@ -455,8 +455,14 @@ media_spoiler = create(media_spoiler_filter)
 
 
 # region private_filter
-def private_filter(_, __, m: Message):
-    return bool(m.chat and m.chat.type in {enums.ChatType.PRIVATE, enums.ChatType.BOT})
+def private_filter(_, __, m: CallbackQuery | Message):
+    if isinstance(m, Message):
+        value = m.chat
+    elif isinstance(m, CallbackQuery):
+        value = m.message.chat
+    else:
+        raise ValueError(f"Private filter doesn't work with {type(m)}")
+    return bool(value and value.type in {enums.ChatType.PRIVATE, enums.ChatType.BOT})
 
 
 private = create(private_filter)
@@ -467,8 +473,14 @@ private = create(private_filter)
 
 
 # region group_filter
-def group_filter(_, __, m: Message):
-    return bool(m.chat and m.chat.type in {enums.ChatType.GROUP, enums.ChatType.SUPERGROUP})
+def group_filter(_, __, m: CallbackQuery | Message):
+    if isinstance(m, Message):
+        value = m.chat
+    elif isinstance(m, CallbackQuery):
+        value = m.message.chat
+    else:
+        raise ValueError(f"Group filter doesn't work with {type(m)}")
+    return bool(value and value.type in {enums.ChatType.GROUP, enums.ChatType.SUPERGROUP})
 
 
 group = create(group_filter)
@@ -479,8 +491,14 @@ group = create(group_filter)
 
 
 # region channel_filter
-def channel_filter(_, __, m: Message):
-    return bool(m.chat and m.chat.type == enums.ChatType.CHANNEL)
+def channel_filter(_, __, m: CallbackQuery | Message):
+    if isinstance(m, Message):
+        value = m.chat
+    elif isinstance(m, CallbackQuery):
+        value = m.message.chat
+    else:
+        raise ValueError(f"Channel filter doesn't work with {type(m)}")
+    return bool(value and value.type == enums.ChatType.CHANNEL)
 
 
 channel = create(channel_filter)

--- a/hydrogram/storage/sqlite_storage.py
+++ b/hydrogram/storage/sqlite_storage.py
@@ -29,7 +29,6 @@ from typing import Any
 import aiosqlite
 
 from hydrogram import raw, utils
-from hydrogram.enums import ChatType
 
 from .base import BaseStorage, InputPeer
 


### PR DESCRIPTION
## Description

The logic for this is similar to that of `filters.regex`. However, this approach does not work for callback queries coming from inline messages, as chat information is not shown to bots there, so there's nothing we can do about these.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
