### PR TITLE
Many improvements to the compiler

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: check-yaml
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.7
+    rev: v0.4.10
     hooks:
       - id: ruff-format
       - id: ruff

--- a/compiler/api/compiler.py
+++ b/compiler/api/compiler.py
@@ -533,37 +533,61 @@ def start(format: bool = False):
             f.write(f"{notice}\n\n")
             f.write(f"{WARNING}\n\n")
 
+            all = []
+
             for t in types:
                 module = t
 
                 if module == "Updates":
                     module = "UpdatesT"
+
+                all.append(t)
 
                 f.write(f"from .{snake(module)} import {t}\n")
 
             if not namespace:
                 f.write(f"from . import {', '.join(filter(bool, namespaces_to_types))}")
 
+            all.extend(filter(bool, namespaces_to_types))
+
+            f.write("\n\n__all__ = [\n")
+            for it in all:
+                f.write(f'    "{it}",\n')
+            f.write("]\n")
+
     for namespace, types in namespaces_to_constructors.items():
         with open(DESTINATION_PATH / "types" / namespace / "__init__.py", "w") as f:
             f.write(f"{notice}\n\n")
             f.write(f"{WARNING}\n\n")
+
+            all = []
 
             for t in types:
                 module = t
 
                 if module == "Updates":
                     module = "UpdatesT"
+
+                all.append(t)
 
                 f.write(f"from .{snake(module)} import {t}\n")
 
             if not namespace:
                 f.write(f"from . import {', '.join(filter(bool, namespaces_to_constructors))}\n")
 
+            all.extend(filter(bool, namespaces_to_constructors))
+
+            f.write("\n\n__all__ = [\n")
+            for it in all:
+                f.write(f'    "{it}",\n')
+            f.write("]\n")
+
     for namespace, types in namespaces_to_functions.items():
         with open(DESTINATION_PATH / "functions" / namespace / "__init__.py", "w") as f:
             f.write(f"{notice}\n\n")
             f.write(f"{WARNING}\n\n")
+
+            all = []
 
             for t in types:
                 module = t
@@ -571,10 +595,19 @@ def start(format: bool = False):
                 if module == "Updates":
                     module = "UpdatesT"
 
+                all.append(t)
+
                 f.write(f"from .{snake(module)} import {t}\n")
 
             if not namespace:
                 f.write(f"from . import {', '.join(filter(bool, namespaces_to_functions))}")
+
+            all.extend(filter(bool, namespaces_to_functions))
+
+            f.write("\n\n__all__ = [\n")
+            for it in all:
+                f.write(f'    "{it}",\n')
+            f.write("]\n")
 
     with open(DESTINATION_PATH / "all.py", "w", encoding="utf-8") as f:
         f.write(notice + "\n\n")

--- a/compiler/api/compiler.py
+++ b/compiler/api/compiler.py
@@ -25,9 +25,12 @@ from functools import partial
 from pathlib import Path
 from typing import NamedTuple
 
-HOME_PATH = Path("compiler/api")
-DESTINATION_PATH = Path("hydrogram/raw")
-NOTICE_PATH = "NOTICE"
+API_HOME_PATH = Path(__file__).parent.resolve()
+REPO_HOME_PATH = API_HOME_PATH.parent.parent
+
+DESTINATION_PATH = REPO_HOME_PATH / "hydrogram" / "raw"
+NOTICE_PATH = REPO_HOME_PATH / "NOTICE"
+
 
 SECTION_RE = re.compile(r"---(\w+)---")
 LAYER_RE = re.compile(r"//\sLAYER\s(\d+)")
@@ -60,15 +63,15 @@ WARNING = """
 
 open = partial(open, encoding="utf-8")
 
-types_to_constructors = {}
-types_to_functions = {}
-constructors_to_functions = {}
-namespaces_to_types = {}
-namespaces_to_constructors = {}
-namespaces_to_functions = {}
+types_to_constructors: dict[str, list[str]] = {}
+types_to_functions: dict[str, list[str]] = {}
+constructors_to_functions: dict[str, list[str]] = {}
+namespaces_to_types: dict[str, list[str]] = {}
+namespaces_to_constructors: dict[str, list[str]] = {}
+namespaces_to_functions: dict[str, list[str]] = {}
 
 try:
-    with open("docs.json") as f:
+    with open(API_HOME_PATH / "docs.json") as f:
         docs = json.load(f)
 except FileNotFoundError:
     docs = {"type": {}, "constructor": {}, "method": {}}
@@ -94,7 +97,7 @@ def snake(s: str):
 
 
 def camel(s: str):
-    return "".join([i[0].upper() + i[1:] for i in s.split("_")])
+    return "".join(i[0].upper() + i[1:] for i in s.split("_"))
 
 
 def get_type_hint(type: str) -> str:
@@ -135,7 +138,7 @@ def get_type_hint(type: str) -> str:
     return f'{type}{" = None" if is_flag else ""}'
 
 
-def sort_args(args):
+def sort_args(args: list[tuple[str, str]]):
     """Put flags at the end"""
     args = args.copy()
     flags = [i for i in args if FLAGS_RE.match(i[1])]
@@ -186,13 +189,13 @@ def get_docstring_arg_type(t: str):
 
 def get_references(t: str, kind: str):
     if kind == "constructors":
-        t = constructors_to_functions.get(t)
+        items = constructors_to_functions.get(t)
     elif kind == "types":
-        t = types_to_functions.get(t)
+        items = types_to_functions.get(t)
     else:
         raise ValueError("Invalid kind")
 
-    return ("\n            ".join(t), len(t)) if t else (None, 0)
+    return ("\n            ".join(items), len(items)) if items else (None, 0)
 
 
 def start(format: bool = False):
@@ -201,25 +204,25 @@ def start(format: bool = False):
     shutil.rmtree(DESTINATION_PATH / "base", ignore_errors=True)
 
     with (
-        open(HOME_PATH / "source/auth_key.tl") as f1,
-        open(HOME_PATH / "source/sys_msgs.tl") as f2,
-        open(HOME_PATH / "source/main_api.tl") as f3,
+        open(API_HOME_PATH / "source/auth_key.tl") as f1,
+        open(API_HOME_PATH / "source/sys_msgs.tl") as f2,
+        open(API_HOME_PATH / "source/main_api.tl") as f3,
     ):
         schema = (f1.read() + f2.read() + f3.read()).splitlines()
 
     with (
-        open(HOME_PATH / "template/type.txt") as f1,
-        open(HOME_PATH / "template/combinator.txt") as f2,
+        open(API_HOME_PATH / "template/type.txt") as f1,
+        open(API_HOME_PATH / "template/combinator.txt") as f2,
     ):
         type_tmpl = f1.read()
         combinator_tmpl = f2.read()
 
-    with open(NOTICE_PATH, encoding="utf-8") as f:
+    with open(NOTICE_PATH) as f:
         notice = [f"#  {line}".strip() for line in f]
         notice = "\n".join(notice)
 
     layer = None
-    combinators = []
+    combinators: list[Combinator] = []
 
     section = None
     for line in schema:
@@ -295,7 +298,7 @@ def start(format: bool = False):
             with contextlib.suppress(KeyError):
                 constructors_to_functions[i] = types_to_functions[k]
 
-    for qualtype in types_to_constructors:
+    for qualtype, qualval in types_to_constructors.items():
         typespace, type = qualtype.split(".") if "." in qualtype else ("", qualtype)
         dir_path = DESTINATION_PATH / "base" / typespace
 
@@ -304,9 +307,9 @@ def start(format: bool = False):
         if module == "Updates":
             module = "UpdatesT"
 
-        Path(dir_path).mkdir(parents=True, exist_ok=True)
+        dir_path.mkdir(parents=True, exist_ok=True)
 
-        constructors = sorted(types_to_constructors[qualtype])
+        constructors = sorted(qualval)
         constr_count = len(constructors)
         items = "\n            ".join([f"{c}" for c in constructors])
 
@@ -508,7 +511,7 @@ def start(format: bool = False):
 
         dir_path = DESTINATION_PATH / directory / c.namespace
 
-        Path(dir_path).mkdir(exist_ok=True, parents=True)
+        dir_path.mkdir(exist_ok=True, parents=True)
 
         module = c.name
 
@@ -595,8 +598,4 @@ def start(format: bool = False):
 
 
 if __name__ == "__main__":
-    HOME_PATH = Path()
-    DESTINATION_PATH = Path("../../hydrogram/raw")
-    NOTICE_PATH = Path("../../NOTICE")
-
     start(format=False)

--- a/compiler/docs/compiler.py
+++ b/compiler/docs/compiler.py
@@ -645,8 +645,7 @@ def hydrogram_api():
 
 
 def start():
-    global page_template
-    global toctree
+    global page_template, toctree
 
     shutil.rmtree(DESTINATION, ignore_errors=True)
 

--- a/compiler/errors/compiler.py
+++ b/compiler/errors/compiler.py
@@ -23,33 +23,35 @@ import re
 import shutil
 from pathlib import Path
 
-HOME = "compiler/errors"
-DEST = "hydrogram/errors/exceptions"
-NOTICE_PATH = "NOTICE"
+ERRORS_HOME_PATH = Path(__file__).parent.resolve()
+REPO_HOME_PATH = ERRORS_HOME_PATH.parent.parent
+
+ERRORS_DEST_PATH = REPO_HOME_PATH / "hydrogram" / "errors" / "exceptions"
+NOTICE_PATH = REPO_HOME_PATH / "NOTICE"
 
 
-def snek(s):
+def snake(s):
     # https://stackoverflow.com/questions/1175208/elegant-python-function-to-convert-camelcase-to-snake-case
     s = re.sub(r"(.)([A-Z][a-z]+)", r"\1_\2", s)
     return re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", s).lower()
 
 
-def caml(s):
-    s = snek(s).split("_")
-    return "".join([str(i.title()) for i in s])
+def camel(s):
+    s = snake(s).split("_")
+    return "".join(str(i.title()) for i in s)
 
 
 def start():
-    shutil.rmtree(DEST, ignore_errors=True)
-    Path(DEST).mkdir(parents=True)
+    shutil.rmtree(ERRORS_DEST_PATH, ignore_errors=True)
+    ERRORS_DEST_PATH.mkdir(parents=True)
 
-    files = os.listdir(f"{HOME}/source")
+    files = os.listdir(f"{ERRORS_HOME_PATH}/source")
 
-    with Path(NOTICE_PATH).open(encoding="utf-8") as f:
+    with NOTICE_PATH.open(encoding="utf-8") as f:
         notice = [f"# {line}".strip() for line in f]
         notice = "\n".join(notice)
 
-    with Path(f"{DEST}/all.py").open("w", encoding="utf-8") as f_all:
+    with (ERRORS_DEST_PATH / "all.py").open("w", encoding="utf-8") as f_all:
         f_all.write(notice + "\n\n")
         f_all.write("count = {count}\n\n")
         f_all.write("exceptions = {\n")
@@ -61,24 +63,26 @@ def start():
 
             f_all.write(f"    {code}: {{\n")
 
-            init = f"{DEST}/__init__.py"
+            init = ERRORS_DEST_PATH / "__init__.py"
 
-            if not Path(init).exists():
-                with Path(init).open("w", encoding="utf-8") as f_init:
+            if not init.exists():
+                with init.open("w", encoding="utf-8") as f_init:
                     f_init.write(notice + "\n\n")
 
-            with Path(init).open("a", encoding="utf-8") as f_init:
+            with init.open("a", encoding="utf-8") as f_init:
                 f_init.write(f"from .{name.lower()}_{code} import *\n")
 
             with (
-                Path(f"{HOME}/source/{i}").open(encoding="utf-8") as f_csv,
-                Path(f"{DEST}/{name.lower()}_{code}.py").open("w", encoding="utf-8") as f_class,
+                (ERRORS_HOME_PATH / "source" / i).open(encoding="utf-8") as f_csv,
+                (ERRORS_DEST_PATH / f"{name.lower()}_{code}.py").open(
+                    "w", encoding="utf-8"
+                ) as f_class,
             ):
                 reader = csv.reader(f_csv, delimiter="\t")
 
-                super_class = caml(name)
+                super_class = camel(name)
                 name = " ".join([
-                    str(i.capitalize()) for i in re.sub(r"_", " ", name).lower().split(" ")
+                    i.capitalize() for i in re.sub(r"_", " ", name).lower().split(" ")
                 ])
 
                 sub_classes = []
@@ -96,7 +100,7 @@ def start():
 
                     error_id, error_message = row
 
-                    sub_class = caml(re.sub(r"_X", "_", error_id))
+                    sub_class = camel(re.sub(r"_X", "_", error_id))
                     sub_class = re.sub(r"^2", "Two", sub_class)
                     sub_class = re.sub(r" ", "", sub_class)
 
@@ -104,10 +108,12 @@ def start():
 
                     sub_classes.append((sub_class, error_id, error_message))
 
-                with Path(f"{HOME}/template/class.txt").open(encoding="utf-8") as f_class_template:
+                with (ERRORS_HOME_PATH / "template" / "class.txt").open(
+                    encoding="utf-8"
+                ) as f_class_template:
                     class_template = f_class_template.read()
 
-                    with Path(f"{HOME}/template/sub_class.txt").open(
+                    with (ERRORS_HOME_PATH / "template" / "sub_class.txt").open(
                         encoding="utf-8"
                     ) as f_sub_class_template:
                         sub_class_template = f_sub_class_template.read()
@@ -134,16 +140,12 @@ def start():
 
         f_all.write("}\n")
 
-    with Path(f"{DEST}/all.py").open(encoding="utf-8") as f:
+    with (ERRORS_DEST_PATH / "all.py").open(encoding="utf-8") as f:
         content = f.read()
 
-    with Path(f"{DEST}/all.py").open("w", encoding="utf-8") as f:
+    with (ERRORS_DEST_PATH / "all.py").open("w", encoding="utf-8") as f:
         f.write(re.sub("{count}", str(count), content))  # noqa: RUF027
 
 
 if __name__ == "__main__":
-    HOME = "."
-    DEST = "../../hydrogram/errors/exceptions"
-    NOTICE_PATH = "../../NOTICE"
-
     start()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,6 @@ exclude = [
     ".editorconfig",
     ".gitignore",
     ".pre-commit-config.yaml",
-    "compiler/api/docs.json",
     "CONTRIBUTING.md",
     "NEWS.rst",
     "requirements.lock",


### PR DESCRIPTION
This PR adds many improvements to the compiler, most notably:
 - Completely move it into pathlib
 - Improved typing hints
 - Fix new ruff lints
 - Use absolute paths instead of relative ones

The compiler can now be invoked from any folder, and it's no longer necessary to `cd` into it. This also fixes a problem where installing from pip didn't include raw API documentation (which affected RTD too).